### PR TITLE
build: use releases in HACS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+install: echo "Nothing to install, $TRAVIS_TAG"
+script: echo "Nothing to test" && true
+before_deploy:
+  - cd custom_components/wibee
+  - zip -r hass_wibee .
+deploy:
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  tag_name: $TRAVIS_TAG
+  name: $TRAVIS_TAG
+  file: hass_wibee.zip
+  skip_cleanup: true
+  draft: true
+  prerelease: true
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # Home Assistant: Wibeee Component
 ![wibeee_logo](https://wibeee.com/wp-content/uploads/2018/09/logo.png)
 
-This is a Home Assistant Custom Component originally developed to integrate CIRCUTOR WiBeee (3 phase)
-energy monitors. It has also been found to work on on similar devices that are listed below:
+This is a Home Assistant Custom Component originally developed to integrate CIRCUTOR Wibeee (3 phase)
+and Mirubee energy monitors. It has been found to work on on similar devices that are listed below:
 
 | Device        | Model           | Link  |
 | ------------- |:-------------:| -----:|

--- a/custom_components/wibeee/manifest.json
+++ b/custom_components/wibeee/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "wibeee",
   "name": "wibeee",
-  "version": "1.0",
+  "version": "2.0.0",
   "documentation": "https://github.com/luuuis/hass_wibeee",
   "issue_tracker": "https://github.com/luuuis/hass_wibeee/issues",
   "dependencies": [],

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,7 @@
 {
     "name": "Wibeee (and Mirubee) energy monitor",
-    "render_readme": true
+    "render_readme": true,
+    "hide_default_branch": true,
+    "zip_release": true,
+    "filename": "hass_wibee.zip"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,6 @@
 {
     "name": "Wibeee (and Mirubee) energy monitor",
     "render_readme": true,
-    "hide_default_branch": true,
     "zip_release": true,
     "filename": "hass_wibee.zip"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-    "name": "CIRCUTOR WiBeee (and Mirubee) energy monitor integration",
+    "name": "Wibeee (and Mirubee) energy monitor",
     "render_readme": true
 }


### PR DESCRIPTION
Configures [Travis Releases Uploading](https://docs.travis-ci.com/user/deployment/releases/) and tells HACS to use releases instead of the main branch.