### PR TITLE
feat: add scan_interval support to allow this to be user-configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,25 @@ of the energy monitor on your network.
 sensor:
 - platform: wibeee
   host: 192.168.xx.xx # use static IP
+  scan_interval: 5    # optional, defaults to 15 seconds
 ```
 
 Optionally, configure extra template sensors for grid consumption and feed-in to use
 with [Home Energy Management](https://www.home-assistant.io/home-energy-management/). See [SENSOR_EXAMPLES.md](./SENSOR_EXAMPLES.md)
 for suggested sensors that will help you get the most out of the integration.  
+
+### Logging
+
+To set up the logger for this custom component add following lines to configuration.yaml
+
+```yaml
+logger:
+  default: warn
+  logs:
+    custom_components.wibeee.sensor: info
+```
+
+Possible log levels: `info`, `debug`, `warn`, `error`.
 
 # Example View in Home Assistant
 
@@ -71,4 +85,4 @@ for suggested sensors that will help you get the most out of the integration.
 # Useful links
 
 Home Assistant Community thread:
-https://community.home-assistant.io/t/new-integration-energy-monitoring-device-circutor-wibeee/45276
+https://community.home-assistant.io/t/new-integration-energy-monitoring-device-circutor-wibeee/45276/176

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -42,19 +42,11 @@ from homeassistant.const import (
     ENERGY_WATT_HOUR,
     CONF_HOST,
     CONF_SCAN_INTERVAL,
-    CONF_RESOURCE,
-    ATTR_ATTRIBUTION
 )
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.event import async_track_time_interval
 
 import xmltodict
-
-ATTRIBUTION = (
-    "Circutor's energy consumption sensor"
-)
-
-DOMAIN="WIBEEE"
 
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -72,16 +64,13 @@ DOMAIN = 'wibeee_energy'
 DEFAULT_NAME = 'Wibeee Energy Consumption Sensor'
 DEFAULT_HOST = ''
 DEFAULT_RESOURCE = 'http://{}/en/status.xml'
-DEFAULT_SCAN_INTERVAL = 60
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
 DEFAULT_PHASES = 3
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-    vol.Optional(CONF_RESOURCE, default=DEFAULT_RESOURCE): cv.string,
-    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.positive_int,
+    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.time_period,
 })
-
-SCAN_INTERVAL = timedelta(seconds=15)
 
 SENSOR_TYPES = {
     'vrms': ['Vrms', ELECTRIC_POTENTIAL_VOLT, DEVICE_CLASS_VOLTAGE],
@@ -111,7 +100,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # Then make first call and get sensors
     await wibeee_data.set_sensors()
 
-    async_track_time_interval(hass, wibeee_data.fetching_data, SCAN_INTERVAL)
+    scan_interval = config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    _LOGGER.info(f"Start polling {url_api} with scan_interval: {scan_interval}")
+    async_track_time_interval(hass, wibeee_data.fetching_data, scan_interval)
 
     # Add Entities
     if not wibeee_data.sensors:


### PR DESCRIPTION
Read `scan_interval` from the sensor configuration, falling back to the 15 second default.