### PR TITLE
fix: don't error with "Unable to create WibeeeSensor" on unknown keys

### DIFF
--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -194,17 +194,19 @@ class WibeeeData(object):
         # Create tmp sensor array
         tmp_sensors = []
 
-        for key,value in self.data.items():
-          try:
-            _LOGGER.debug("Processing sensor [key:%s] [value:%s]", key, value)  
-            sensor_id = key
-            sensor_phase,sensor_name = key.split("_",1)
-            sensor_phase = sensor_phase.replace("fase","")
-            sensor_value = value
-            _LOGGER.debug("Adding entity [phase:%s][sensor:%s][value:%s]", sensor_phase, sensor_id, sensor_value)
-            tmp_sensors.append(WibeeeSensor(self, self.sensor_name_suffix, sensor_id, sensor_phase, sensor_name,sensor_value))
-          except:
-            _LOGGER.error(f"Unable to create WibeeeSensor Entities for key {key} and value {value}")
+        for key, value in self.data.items():
+            if key.startswith("fase"):
+                try:
+                    _LOGGER.debug("Processing sensor [key:%s] [value:%s]", key, value)
+                    sensor_id = key
+                    sensor_phase, sensor_name = key[4:].split("_", 1)
+                    sensor_value = value
+
+                    _LOGGER.debug("Adding entity [phase:%s][sensor:%s][value:%s]", sensor_phase, sensor_id, sensor_value)
+                    if sensor_name in SENSOR_TYPES:
+                        tmp_sensors.append(WibeeeSensor(self, self.sensor_name_suffix, sensor_id, sensor_phase, sensor_name, sensor_value))
+                except:
+                    _LOGGER.error(f"Unable to create WibeeeSensor Entities for key {key} and value {value}")
 
         # Add sensors
         self.sensors = tmp_sensors


### PR DESCRIPTION
Fixes an error where we try to add an unknown sensor without checking if it should be processed first.

```
2021-08-25 10:04:21 ERROR (MainThread) [custom_components.wibeee.sensor] Unable to create WibeeeSensor Entities for key fase1_angle and value 0.00
Traceback (most recent call last):
  File "/config/custom_components/wibeee/sensor.py", line 204, in set_sensors
    tmp_sensors.append(WibeeeSensor(self, self.sensor_name_suffix, sensor_id, sensor_phase, sensor_name,sensor_value))
  File "/config/custom_components/wibeee/sensor.py", line 126, in __init__
    friendly_name, unit, device_class = SENSOR_TYPES[sensor_name]
KeyError: 'angle'
```