### PR TITLE
fix: don't update entities that are disabled

### DIFF
--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -259,7 +259,8 @@ class WibeeeData(object):
     def updating_sensors(self, sensor_data):
         """Update all sensor states from sensor_data."""
         for sensor in self.sensors:
-            sensor._state = sensor_data.get(sensor._entity, STATE_UNAVAILABLE)
-            sensor._attr_available = sensor._state is not STATE_UNAVAILABLE
-            sensor.async_schedule_update_ha_state()
-            _LOGGER.debug("[sensor:%s] %s)", sensor._entity, sensor._state)
+            if sensor.enabled:
+                sensor._state = sensor_data.get(sensor._entity, STATE_UNAVAILABLE)
+                sensor._attr_available = sensor._state is not STATE_UNAVAILABLE
+                sensor.async_schedule_update_ha_state()
+            _LOGGER.debug("[sensor:%s] %s%s", sensor._entity, sensor._state, '' if sensor.enabled else ' (DISABLED)')


### PR DESCRIPTION
The component tries to update sensors even when they are disabled, triggering this warning.

```
2021-12-11 22:37:44 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.wibeee_xxxxxxxxxxxx_active_energy_l1 is incorrectly being triggered for updates while it is disabled. This is a bug in the wibeee integration
```

Under some conditions this also causes an exception within Home Assistant, causing the custom component to essentially "freeze" and stop updating all the other sensors as well.

```
2021-12-11 22:40:19 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
File "/config/custom_components/wibeee/sensor.py", line 257, in fetching_data
self.updating_sensors(sensor_data=fetched)
File "/config/custom_components/wibeee/sensor.py", line 264, in updating_sensors
sensor.async_schedule_update_ha_state()
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 621, in async_schedule_update_ha_state
self.async_write_ha_state()
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 457, in async_write_ha_state
raise RuntimeError(f"Attribute hass is None for {self}")
RuntimeError: Attribute hass is None for <Entity Wibeee XXXXXXXXXXXX Active Energy L1: 10269753>
```

This change excludes disabled entities from being updated. Fixes #14.