### PR TITLE
feat: add config flow

### DIFF
--- a/custom_components/wibeee/__init__.py
+++ b/custom_components/wibeee/__init__.py
@@ -3,3 +3,50 @@ Support for Energy consumption Sensors from Circutor
 Device's website: http://wibeee.circutor.com/
 Documentation: https://github.com/luuuis/hass_wibeee/
 """
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .api import WibeeeAPI
+from .const import (DOMAIN, DEFAULT_SCAN_INTERVAL, DEFAULT_TIMEOUT)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up platform from a ConfigEntry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {'disposers': {}}
+
+    _LOGGER.info(f"Setup config entry for {entry.title} (unique_id={entry.unique_id})")
+
+    # Forward the setup to the sensor platform.
+    hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, "sensor"))
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    disposers = hass.data[DOMAIN][entry.entry_id]['disposers']
+
+    for name, dispose in list(disposers.items()):
+        _LOGGER.debug(f"Dispose of '{name}', {dispose}")
+        try:
+            dispose()
+            disposers.pop(name)
+        except Exception:
+            _LOGGER.error(f"Dispose failure for '{name}'", exc_info=True)
+
+    _LOGGER.debug(f"Disposers finished.")
+
+    dispose_ok = len(disposers) is 0
+    unload_ok = False
+    if dispose_ok:
+        _LOGGER.debug(f"Unloading sensor entry for {entry.title} (unique_id={entry.unique_id})")
+        unload_ok = await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+        if unload_ok:
+            hass.data[DOMAIN].pop(entry.entry_id)
+
+    _LOGGER.info(f"Unloaded config entry for {entry.title} (unique_id={entry.unique_id})")
+    return dispose_ok and unload_ok

--- a/custom_components/wibeee/api.py
+++ b/custom_components/wibeee/api.py
@@ -1,0 +1,72 @@
+import asyncio
+import logging
+from datetime import timedelta
+from urllib.parse import quote_plus
+
+import aiohttp
+import xmltodict
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WibeeeAPI(object):
+    """Gets the latest data from Wibeee device."""
+
+    def __init__(self, session: aiohttp.ClientSession, host: str, timeout: timedelta):
+        """Initialize the data object."""
+        self.session = session
+        self.host = host
+        self.timeout = timeout
+        self.min_wait = timedelta(milliseconds=100)
+        self.max_wait = min(timedelta(seconds=5), timeout)
+        _LOGGER.info("Initializing WibeeeAPI with host: %s, timeout %s, max_wait: %s", host, self.timeout, self.max_wait)
+
+    async def async_fetch_status(self, retries: int = 0):
+        """Fetches the status XML from Wibeee as a dict, optionally retries"""
+        status = await self.async_fetch_url(f'http://{self.host}/en/status.xml', retries)
+        return status["response"]
+
+    async def async_fetch_device_info(self, retries: int):
+        # <devices><id>WIBEEE</id></devices>
+        devices = await self.async_fetch_url(f'http://{self.host}/services/user/devices.xml', retries)
+        device_id = devices['devices']['id']
+
+        # <values><variable><id>macAddr</id><value>11:11:11:11:11:11</value></variable></values>
+        values = await self.async_fetch_url(f'http://{self.host}/services/user/values.xml?var={quote_plus(device_id)}.macAddr', retries)
+        mac_addr = values['values']['variable']['value']
+
+        return dict(id=device_id, mac_addr=mac_addr.replace(":", "").lower()) if device_id and mac_addr else None
+
+    async def async_fetch_url(self, url, retries: int = 0):
+        async def fetch_with_retries(try_n):
+            if try_n > 0:
+                wait = min(pow(2, try_n) * self.min_wait.total_seconds(), self.max_wait.total_seconds())
+                _LOGGER.debug("Waiting %0.3fs to retry %s...", wait, url)
+                await asyncio.sleep(wait)
+
+            try:
+                resp = await self.session.get(url, timeout=self.timeout.total_seconds())
+                if resp.status != 200:
+                    raise aiohttp.ClientResponseError(
+                        resp.request_info,
+                        resp.history,
+                        status=resp.status,
+                        message=resp.reason,
+                        headers=resp.headers,
+                    )
+
+                xml_data = await resp.text()
+                _LOGGER.debug("RAW Response from %s: %s)", url, xml_data)
+                xml_as_dict = xmltodict.parse(xml_data)
+                return xml_as_dict
+
+            except Exception as exc:
+                if try_n == retries:
+                    retry_info = f' after {try_n} retries' if retries > 0 else ''
+                    _LOGGER.error('Error getting %s%s: %s: %s', url, retry_info, exc.__class__.__name__, exc, exc_info=True)
+                    return {}
+                else:
+                    _LOGGER.warning('Error getting %s, will retry. %s: %s', url, exc.__class__.__name__, exc, exc_info=True)
+                    return await fetch_with_retries(try_n + 1)
+
+        return await fetch_with_retries(0)

--- a/custom_components/wibeee/config_flow.py
+++ b/custom_components/wibeee/config_flow.py
@@ -1,0 +1,72 @@
+"""Config flow for Wibeee integration."""
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+import voluptuous as vol
+from homeassistant import config_entries, exceptions
+from homeassistant.const import (CONF_HOST)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
+
+from .api import WibeeeAPI
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def validate_input(hass: HomeAssistant, user_input: dict) -> [str, str, dict[str, Any]]:
+    """Validate the user input allows us to connect. """
+    session = async_get_clientsession(hass)
+    api = WibeeeAPI(session, user_input[CONF_HOST], timeout=timedelta(seconds=1))
+    try:
+        device = await api.async_fetch_device_info(retries=5)
+    except Exception as e:
+        raise NoDeviceInfo from e
+
+    mac_addr = format_mac(device['mac_addr'])
+    unique_id = mac_addr
+    name = f"Wibeee {mac_addr.replace(':', '')[-6:].upper()}"
+
+    return name, unique_id, {CONF_HOST: user_input[CONF_HOST], }
+
+
+class WibeeeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Wibeee config flow."""
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                title, unique_id, data = await validate_input(self.hass, user_input)
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(title=title, data=data)
+
+            except NoDeviceInfo:
+                # host is not a Wibeee...
+                errors[CONF_HOST] = "no_device_info"
+
+            except Exception:
+                _LOGGER.exception("Unexpected exception", exc_info=True)
+                errors["base"] = "unknown"
+
+        return await self._show_setup_form(errors)
+
+    async def async_step_import(self, conf: dict):
+        """Import a configuration from config.yaml."""
+        return await self.async_step_user(user_input={CONF_HOST: conf[CONF_HOST]})
+
+    async def _show_setup_form(self, errors=None):
+        """Show the setup form to the user."""
+        schema = vol.Schema({vol.Required(CONF_HOST): str, })
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors or {})
+
+
+class NoDeviceInfo(exceptions.HomeAssistantError):
+    """Error to indicate we couldn't get info from Wibeee."""

--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -1,0 +1,6 @@
+from datetime import timedelta
+
+DOMAIN = 'wibeee'
+
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
+DEFAULT_TIMEOUT = timedelta(seconds=10)

--- a/custom_components/wibeee/manifest.json
+++ b/custom_components/wibeee/manifest.json
@@ -9,5 +9,6 @@
     "@luuuis"
   ],
   "requirements": [],
+  "config_flow": true,
   "iot_class": "local_polling"
 }

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -8,21 +8,16 @@ Documentation: https://github.com/luuuis/hass_wibeee/
 
 REQUIREMENTS = ["xmltodict"]
 
-import aiohttp
-import asyncio
 import logging
-import voluptuous as vol
 from datetime import timedelta
-from urllib.parse import quote_plus
 
-from homeassistant.util import slugify
 import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA,
     STATE_CLASS_MEASUREMENT,
     SensorEntity,
 )
-
 from homeassistant.const import (
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_ENERGY,
@@ -41,14 +36,13 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.event import async_track_time_interval
-
-import xmltodict
-
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util import slugify
 
-__version__ = '0.0.2'
+from .api import WibeeeAPI
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,42 +73,51 @@ SENSOR_TYPES = {
 }
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_platform(hass: HomeAssistant, config, async_add_entities, discovery_info=None):
     """Set up the RESTful sensor."""
     _LOGGER.debug("Setting up Wibeee Sensors...")
 
+    session = async_get_clientsession(hass)
     host = config.get(CONF_HOST)
-
-    # Create a WIBEEE DATA OBJECT
     scan_interval = config.get(CONF_SCAN_INTERVAL)
     timeout = config.get(CONF_TIMEOUT)
     unique_id = config.get(CONF_UNIQUE_ID)
-    wibeee_data = WibeeeData(hass, host, unique_id, scan_interval, timeout)
 
-    # Then make first call and get sensors
-    await wibeee_data.set_sensors()
+    api = WibeeeAPI(session, host, min(timeout, scan_interval))
+    device = await api.async_fetch_device_info(retries=5) if unique_id else None
+    status = await api.async_fetch_status(retries=10)
+
+    sensors = WibeeeSensor.make_device_sensors(device, status)
+    for sensor in sensors:
+        _LOGGER.debug("Adding '%s' (unique_id=%s)", sensor, sensor.unique_id)
+    async_add_entities(sensors, True)
+
+    async def fetching_data(now=None):
+        """Fetch from API and update sensors."""
+        try:
+            fetched = await api.async_fetch_status(retries=3)
+            for s in sensors:
+                s.update_from_status(fetched)
+        except Exception as err:
+            if now is None:
+                raise PlatformNotReady from err
 
     _LOGGER.debug(f"Start polling {host} with scan_interval: {scan_interval}")
-    async_track_time_interval(hass, wibeee_data.fetching_data, scan_interval)
+    async_track_time_interval(hass, fetching_data, scan_interval)
 
-    async_add_entities(wibeee_data.sensors, True)
-
-    # Setup Completed
     _LOGGER.debug("Setup completed!")
-
     return True
 
 
 class WibeeeSensor(SensorEntity):
     """Implementation of Wibeee sensor."""
 
-    def __init__(self, wibeee_data, device, sensor_id, sensor_phase, status_xml_name, sensor_value):
+    def __init__(self, device, xml_name: str, sensor_phase: str, sensor_type: str, sensor_value):
         """Initialize the sensor."""
-        ha_name, friendly_name, unit, device_class = SENSOR_TYPES[status_xml_name]
-        [device_name, mac_addr] = [device['id'], device['mac_addr']] if device else ["Wibeee", None]
+        ha_name, friendly_name, unit, device_class = SENSOR_TYPES[sensor_type]
+        [device_name, mac_addr] = [device['id'], device['mac_addr']]
         entity_id = slugify(f"Wibeee {mac_addr} {friendly_name} L{sensor_phase}" if mac_addr else f"wibeee_Phase{sensor_phase}_{ha_name}")
-        self._wibeee_data = wibeee_data
-        self._sensor_id = sensor_id
+        self._xml_name = xml_name
         self._attr_native_unit_of_measurement = unit
         self._attr_native_value = sensor_value
         self._attr_available = True
@@ -125,119 +128,18 @@ class WibeeeSensor(SensorEntity):
         self._attr_should_poll = False
         self.entity_id = f"sensor.{entity_id}"  # we don't want this derived from the name
 
+    @callback
+    def update_from_status(self, status) -> None:
+        """Updates this sensor from the fetched status."""
+        if self.enabled:
+            self._attr_native_value = status.get(self._xml_name, STATE_UNAVAILABLE)
+            self._attr_available = self.state is not STATE_UNAVAILABLE
+            self.async_schedule_update_ha_state()
+            _LOGGER.debug("Updating '%s'", self)
 
-class WibeeeData(object):
-    """Gets the latest data from Wibeee sensors."""
-
-    def __init__(self, hass, host, unique_id, scan_interval, timeout):
-        """Initialize the data object."""
-
-        self.hass = hass
-        self.host = host
-        self.unique_id = unique_id
-        self.timeout = min(timeout, scan_interval)
-        self.min_wait = timedelta(milliseconds=100)
-        self.max_wait = min(timedelta(seconds=5), scan_interval)
-        _LOGGER.info("Initializing WibeeeData with host: %s, scan_interval: %s, timeout %s, max_wait: %s", host, scan_interval,
-                     self.timeout, self.max_wait)
-
-        self.session = async_get_clientsession(hass)
-
-        self.sensors = None
-
-    async def async_fetch_status(self, retries=0):
-        """Fetches the status XML from Wibeee as a dict, optionally retries"""
-        status = await self.async_fetch_url(f'http://{self.host}/en/status.xml', retries)
-        return status["response"]
-
-    async def async_fetch_device_info(self, retries):
-        try:
-            # <devices><id>WIBEEE</id></devices>
-            devices = await self.async_fetch_url(f'http://{self.host}/services/user/devices.xml', retries)
-            device_id = devices['devices']['id']
-            # <values><variable><id>macAddr</id><value>11:11:11:11:11:11</value></variable></values>
-            values = await self.async_fetch_url(f'http://{self.host}/services/user/values.xml?var={quote_plus(device_id)}.macAddr', retries)
-            mac_addr = values['values']['variable']['value']
-            return dict(id=device_id, mac_addr=mac_addr.replace(":", "").lower()) if device_id and mac_addr else None
-        except Exception:
-            _LOGGER.warning("Error getting device info, sensors will not have a unique ID", exc_info=True)
-            return None
-
-    async def async_fetch_url(self, url, retries=0):
-        async def fetch_with_retries(try_n):
-            if try_n > 0:
-                wait = min(pow(2, try_n) * self.min_wait.total_seconds(), self.max_wait.total_seconds())
-                _LOGGER.debug("Waiting %0.3fs to retry %s...", wait, url)
-                await asyncio.sleep(wait)
-
-            try:
-                resp = await self.session.get(url, timeout=self.timeout.total_seconds())
-                if resp.status != 200:
-                    raise aiohttp.ClientResponseError(
-                        resp.request_info,
-                        resp.history,
-                        status=resp.status,
-                        message=resp.reason,
-                        headers=resp.headers,
-                    )
-
-                xml_data = await resp.text()
-                _LOGGER.debug("RAW Response from %s: %s)", url, xml_data)
-                xml_as_dict = xmltodict.parse(xml_data)
-                return xml_as_dict
-
-            except Exception as exc:
-                if try_n == retries:
-                    retry_info = f' after {try_n} retries' if retries > 0 else ''
-                    _LOGGER.error('Error getting %s%s: %s: %s', url, retry_info, exc.__class__.__name__, exc, exc_info=True)
-                    return {}
-                else:
-                    _LOGGER.warning('Error getting %s, will retry. %s: %s', url, exc.__class__.__name__, exc, exc_info=True)
-                    return await fetch_with_retries(try_n + 1)
-
-        return await fetch_with_retries(0)
-
-    async def set_sensors(self):
-        """Make first Get call to Initialize sensor names"""
-        device = await self.async_fetch_device_info(retries=5) if self.unique_id else None
-        status = await self.async_fetch_status(retries=10)
-
-        # Create tmp sensor array
-        tmp_sensors = []
-
-        for key, value in status.items():
-            if key.startswith("fase"):
-                try:
-                    sensor_id = key
-                    sensor_phase, sensor_name = key[4:].split("_", 1)
-                    sensor_value = value
-
-                    if sensor_name in SENSOR_TYPES:
-                        sensor = WibeeeSensor(self, device, sensor_id, sensor_phase, sensor_name, sensor_value)
-                        _LOGGER.debug("Adding '%s' (unique_id=%s)", sensor, sensor.unique_id)
-                        tmp_sensors.append(sensor)
-                except:
-                    _LOGGER.error(f"Unable to create WibeeeSensor Entities for key {key} and value {value}", exc_info=True)
-
-        # Add sensors
-        self.sensors = tmp_sensors
-
-    async def fetching_data(self, now=None):
-        """ Function to fetch REST Data and transform XML to data to DICT format """
-        try:
-            fetched = await self.async_fetch_status(retries=3)
-        except Exception as err:
-            fetched = {}
-            if now is None:
-                raise PlatformNotReady from err
-
-        self.updating_sensors(sensor_data=fetched)
-
-    def updating_sensors(self, sensor_data):
-        """Update all sensor states from sensor_data."""
-        for sensor in self.sensors:
-            if sensor.enabled:
-                sensor._attr_native_value = sensor_data.get(sensor._sensor_id, STATE_UNAVAILABLE)
-                sensor._attr_available = sensor.state is not STATE_UNAVAILABLE
-                sensor.async_schedule_update_ha_state()
-                _LOGGER.debug("Updating '%s'", sensor)
+    @staticmethod
+    def make_device_sensors(device, status) -> list['WibeeeSensor']:
+        """Returns a list of the sensors discovered on the device."""
+        phase_values = [(key, value, key[4:].split("_", 1)) for key, value in status.items() if key.startswith('fase')]
+        known_values = [(key, phase, stype, value) for (key, value, (phase, stype)) in phase_values]
+        return [WibeeeSensor(device, key, phase, stype, value) for (key, phase, stype, value) in known_values if stype in SENSOR_TYPES]

--- a/custom_components/wibeee/translations/en.json
+++ b/custom_components/wibeee/translations/en.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Add Wibeee device",
+        "description": "Enter energy meter information.",
+        "data": {
+          "host": "Hostname or IP address"
+        }
+      }
+    },
+    "error": {
+      "no_device_info": "Couldn't read device info.",
+      "unknown": "Unknown error."
+    }
+  }
+}


### PR DESCRIPTION
Adds a config flow to the integration as per [Integration Configuration](https://developers.home-assistant.io/docs/config_entries_config_flow_handler). This makes it easy to add and remove Wibeee devices without needing to go into YAML and without needing a restart.

![Configuration - Home Assistant 2021-12-29 01-08-21](https://user-images.githubusercontent.com/161006/147618048-25206d88-6f41-43db-8e0b-2a6ad9be1770.jpg)
![Configuration - Home Assistant 2021-12-29 01-09-26](https://user-images.githubusercontent.com/161006/147618112-cbf0890f-d36c-4509-9901-94b65cc69229.jpg)

Existing `platform: wibeee` YAML configuration is imported and ignored afterwards. Currently doesn't support overriding `scan_interval`.

#### ⚠️ Breaking change ⚠️
Removes the `unique_id: false` option introduced in https://github.com/luuuis/hass_wibeee/pull/12 (only released in betas so far). Going forward all sensor and config entries will have a unique id.