### PR TITLE
feat: add config flow options

### DIFF
--- a/custom_components/wibeee/__init__.py
+++ b/custom_components/wibeee/__init__.py
@@ -19,7 +19,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {'disposers': {}}
 
-    _LOGGER.info(f"Setup config entry for {entry.title} (unique_id={entry.unique_id})")
+    _LOGGER.info(f"Setup config entry '{entry.title}' (unique_id={entry.unique_id})")
+
+    # Update things based on options
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
 
     # Forward the setup to the sensor platform.
     hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, "sensor"))
@@ -48,5 +51,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if unload_ok:
             hass.data[DOMAIN].pop(entry.entry_id)
 
-    _LOGGER.info(f"Unloaded config entry for {entry.title} (unique_id={entry.unique_id})")
+    _LOGGER.info(f"Unloaded config entry '{entry.title}' (unique_id={entry.unique_id})")
     return dispose_ok and unload_ok
+
+
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update options."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/wibeee/translations/en.json
+++ b/custom_components/wibeee/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Add Wibeee device",
-        "description": "Enter energy meter information.",
+        "description": "If using an IP address make sure the device is configured with a static IP address or DHCP assignment.",
         "data": {
           "host": "Hostname or IP address"
         }
@@ -12,6 +12,17 @@
     "error": {
       "no_device_info": "Couldn't read device info.",
       "unknown": "Unknown error."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Wibeee integration options",
+        "description": "Customize the integration.",
+        "data": {
+          "scan_interval": "Device polling interval in seconds."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Allows configuring the `scan_interval` as was previously possible using YAML. Also contains some minor tweaks to logging.

![Configuration - Home Assistant 2021-12-31 16-21-19](https://user-images.githubusercontent.com/161006/147832222-d56a089f-3705-4314-88a7-85e1c2c22563.jpg)