### PR TITLE
feat: implement device info

### DIFF
--- a/custom_components/wibeee/config_flow.py
+++ b/custom_components/wibeee/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.device_registry import format_mac
 
 from .api import WibeeeAPI
 from .const import (DOMAIN, DEFAULT_SCAN_INTERVAL)
+from .util import short_mac
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ async def validate_input(hass: HomeAssistant, user_input: dict) -> [str, str, di
 
     mac_addr = format_mac(device['mac_addr'])
     unique_id = mac_addr
-    name = f"Wibeee {mac_addr.replace(':', '')[-6:].upper()}"
+    name = f"Wibeee {short_mac(mac_addr)}"
 
     return name, unique_id, {CONF_HOST: user_input[CONF_HOST], }
 

--- a/custom_components/wibeee/config_flow.py
+++ b/custom_components/wibeee/config_flow.py
@@ -27,7 +27,7 @@ async def validate_input(hass: HomeAssistant, user_input: dict) -> [str, str, di
     except Exception as e:
         raise NoDeviceInfo from e
 
-    mac_addr = format_mac(device['mac_addr'])
+    mac_addr = format_mac(device['macAddr'])
     unique_id = mac_addr
     name = f"Wibeee {short_mac(mac_addr)}"
 

--- a/custom_components/wibeee/util.py
+++ b/custom_components/wibeee/util.py
@@ -1,0 +1,3 @@
+def short_mac(mac_addr):
+    """Returns the last 6 chars of the MAC address for showing in UI."""
+    return mac_addr.replace(':', '')[-6:].upper()


### PR DESCRIPTION
Adds `device_info` property to sensors so that they nest nicely within HA "devices":
- One device for the energy meter. The sensors containing the totals are under this device.
- One device for each of the 3 clamps. Holds the set of sensors for a single clamp.

#### After adding the integration
![Configuration - Home Assistant 2022-01-03 22-50-39](https://user-images.githubusercontent.com/161006/147988960-9fe413fb-1581-4f03-a8b9-25263447e0b6.jpg)

#### Energy meter device
![Configuration - Home Assistant 2022-01-03 22-54-28](https://user-images.githubusercontent.com/161006/147989082-2f45b4cf-84cf-4915-82ad-fcf09886e85b.jpg)

#### Clamps
![Configuration - Home Assistant 2022-01-03 22-59-09](https://user-images.githubusercontent.com/161006/147989441-e917c25e-3636-4547-9cda-e0061f7e7122.jpg)
