### PR TITLE
build: sort manifest keys as required by next HA versions

### DIFF
--- a/custom_components/wibeee/manifest.json
+++ b/custom_components/wibeee/manifest.json
@@ -1,16 +1,16 @@
 {
   "domain": "wibeee",
   "name": "wibeee",
-  "version": "3.2.2",
-  "documentation": "https://github.com/luuuis/hass_wibeee",
-  "issue_tracker": "https://github.com/luuuis/hass_wibeee/issues",
-  "dependencies": [
-    "network"
-  ],
   "codeowners": [
     "@luuuis"
   ],
-  "requirements": [],
   "config_flow": true,
-  "iot_class": "local_polling"
+  "dependencies": [
+    "network"
+  ],
+  "documentation": "https://github.com/luuuis/hass_wibeee",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/luuuis/hass_wibeee/issues",
+  "requirements": [],
+  "version": "3.2.2"
 }


### PR DESCRIPTION
sort manifest keys per https://github.com/home-assistant/core/pull/87020