### PR TITLE
fix: update data when trying to add a device that's already configured

### DIFF
--- a/custom_components/wibeee/config_flow.py
+++ b/custom_components/wibeee/config_flow.py
@@ -46,7 +46,7 @@ class WibeeeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 title, unique_id, data = await validate_input(self.hass, user_input)
                 await self.async_set_unique_id(unique_id)
-                self._abort_if_unique_id_configured()
+                self._abort_if_unique_id_configured(updates=user_input)
 
                 return self.async_create_entry(title=title, data=data)
 

--- a/custom_components/wibeee/translations/en.json
+++ b/custom_components/wibeee/translations/en.json
@@ -9,6 +9,9 @@
         }
       }
     },
+    "abort": {
+      "already_configured": "Device is already configured"
+    },
     "error": {
       "no_device_info": "Couldn't read device info.",
       "unknown": "Unknown error."


### PR DESCRIPTION
Allow HA to update a device's data when the device is already configured.

![Settings – Home Assistant 2023-03-09 00-09-15](https://user-images.githubusercontent.com/161006/223881483-440035fa-744a-4b8a-94ef-2ed6c715420c.jpg)
