### PR TITLE
Add configuration options to change the upstream URL

### DIFF
--- a/custom_components/wibeee/config_flow.py
+++ b/custom_components/wibeee/config_flow.py
@@ -15,14 +15,13 @@ from homeassistant.helpers.device_registry import format_mac
 from .api import WibeeeAPI
 from .const import (
     DOMAIN,
-    NEST_URL,
-    NEST_PORT,
+    NEST_DEFAULT_UPSTREAM,
+    NEST_UPSTREAMS,
     PROXY_PORT,
     DEFAULT_SCAN_INTERVAL,
     CONF_NEST_PROXY_ENABLE,
     CONF_NEST_PROXY_PORT,
-    CONF_NEST_UPSTREAM_URL,
-    CONF_NEST_UPSTREAM_PORT
+    CONF_NEST_UPSTREAM
 )
 from .util import short_mac
 
@@ -103,30 +102,28 @@ class WibeeeOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
+        data_schema = vol.Schema({
+            vol.Optional(
+                CONF_SCAN_INTERVAL,
+                default=self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL.total_seconds())
+            ): int,
+            vol.Optional(
+                CONF_NEST_PROXY_ENABLE,
+                default=self.config_entry.options.get(CONF_NEST_PROXY_ENABLE, False)
+            ): bool,
+            vol.Optional(
+                CONF_NEST_PROXY_PORT,
+                default=self.config_entry.options.get(CONF_NEST_PROXY_PORT, PROXY_PORT)
+            ): int,
+            vol.Optional(
+                CONF_NEST_UPSTREAM,
+                default=self.config_entry.options.get(CONF_NEST_UPSTREAM, NEST_DEFAULT_UPSTREAM)
+            ): vol.In(NEST_UPSTREAMS)
+        })
+
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema({
-                vol.Optional(
-                    CONF_SCAN_INTERVAL,
-                    default=self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL.total_seconds())
-                ): int,
-                vol.Optional(
-                    CONF_NEST_PROXY_ENABLE,
-                    default=self.config_entry.options.get(CONF_NEST_PROXY_ENABLE, False)
-                ): bool,
-                vol.Optional(
-                    CONF_NEST_PROXY_PORT,
-                    default=self.config_entry.options.get(CONF_NEST_PROXY_PORT, PROXY_PORT)
-                ): int,
-                vol.Optional(
-                    CONF_NEST_UPSTREAM_URL,
-                    default=self.config_entry.options.get(CONF_NEST_UPSTREAM_URL, NEST_URL)
-                ): str,
-                vol.Optional(
-                    CONF_NEST_UPSTREAM_PORT,
-                    default=self.config_entry.options.get(CONF_NEST_UPSTREAM_PORT, NEST_PORT)
-                ): int
-            }),
+            data_schema=data_schema,
         )
 
 

--- a/custom_components/wibeee/config_flow.py
+++ b/custom_components/wibeee/config_flow.py
@@ -13,7 +13,17 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
 
 from .api import WibeeeAPI
-from .const import (DOMAIN, DEFAULT_SCAN_INTERVAL, CONF_NEST_PROXY_ENABLE)
+from .const import (
+    DOMAIN,
+    NEST_URL,
+    NEST_PORT,
+    PROXY_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    CONF_NEST_PROXY_ENABLE,
+    CONF_NEST_PROXY_PORT,
+    CONF_NEST_UPSTREAM_URL,
+    CONF_NEST_UPSTREAM_PORT
+)
 from .util import short_mac
 
 _LOGGER = logging.getLogger(__name__)
@@ -103,7 +113,19 @@ class WibeeeOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_NEST_PROXY_ENABLE,
                     default=self.config_entry.options.get(CONF_NEST_PROXY_ENABLE, False)
-                ): bool
+                ): bool,
+                vol.Optional(
+                    CONF_NEST_PROXY_PORT,
+                    default=self.config_entry.options.get(CONF_NEST_PROXY_PORT, PROXY_PORT)
+                ): int,
+                vol.Optional(
+                    CONF_NEST_UPSTREAM_URL,
+                    default=self.config_entry.options.get(CONF_NEST_UPSTREAM_URL, NEST_URL)
+                ): str,
+                vol.Optional(
+                    CONF_NEST_UPSTREAM_PORT,
+                    default=self.config_entry.options.get(CONF_NEST_UPSTREAM_PORT, NEST_PORT)
+                ): int
             }),
         )
 

--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -1,8 +1,7 @@
 from datetime import timedelta
 
 DOMAIN = 'wibeee'
-NEST_URL = 'http://nest-ingest.wibeee.com'
-NEST_PORT = 80
+NEST_DEFAULT_UPSTREAM = 'http://nest-ingest.wibeee.com'
 PROXY_PORT = 8600
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
@@ -10,5 +9,9 @@ DEFAULT_TIMEOUT = timedelta(seconds=10)
 
 CONF_NEST_PROXY_ENABLE = 'nest_proxy_enable'
 CONF_NEST_PROXY_PORT = 'nest_proxy_port'
-CONF_NEST_UPSTREAM_URL = 'nest_upstream_url'
-CONF_NEST_UPSTREAM_PORT = 'nest_upstream_port'
+CONF_NEST_UPSTREAM = 'nest_upstream'
+
+NEST_UPSTREAMS = [
+    'http://nest-ingest.wibeee.com',
+    'http://wdata.solarprofit.es:8080'
+]

--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -1,8 +1,14 @@
 from datetime import timedelta
 
 DOMAIN = 'wibeee'
+NEST_URL = 'http://nest-ingest.wibeee.com'
+NEST_PORT = 80
+PROXY_PORT = 8600
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
 DEFAULT_TIMEOUT = timedelta(seconds=10)
 
 CONF_NEST_PROXY_ENABLE = 'nest_proxy_enable'
+CONF_NEST_PROXY_PORT = 'nest_proxy_port'
+CONF_NEST_UPSTREAM_URL = 'nest_upstream_url'
+CONF_NEST_UPSTREAM_PORT = 'nest_upstream_port'

--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -4,7 +4,6 @@ from homeassistant.helpers.selector import SelectOptionDict
 
 DOMAIN = 'wibeee'
 NEST_DEFAULT_UPSTREAM = 'http://nest-ingest.wibeee.com'
-PROXY_PORT = 8600
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
 DEFAULT_TIMEOUT = timedelta(seconds=10)

--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -21,5 +21,6 @@ NEST_ALL_UPSTREAMS: list[SelectOptionDict] = [SelectOptionDict(label='Disabled (
                                               SelectOptionDict(label='Local only (no Cloud)', value=NEST_NULL_UPSTREAM)] + \
                                              _format_options({
                                                  'Wibeee Nest': NEST_DEFAULT_UPSTREAM,
+                                                 'Iberdrola': 'http://datosmonitorconsumo.iberdrola.es:8080',
                                                  'SolarProfit': 'http://wdata.solarprofit.es:8080',
                                              })

--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -9,7 +9,6 @@ PROXY_PORT = 8600
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
 DEFAULT_TIMEOUT = timedelta(seconds=10)
 
-CONF_NEST_PROXY_ENABLE = 'nest_proxy_enable'
 CONF_NEST_UPSTREAM = 'nest_upstream'
 
 
@@ -17,8 +16,11 @@ def _format_options(upstreams: dict[str, str]) -> list[SelectOptionDict]:
     return [SelectOptionDict(label=f'{cloud} ({url})', value=url) for cloud, url in upstreams.items()]
 
 
-NEST_NULL_UPSTREAM: SelectOptionDict = SelectOptionDict(label='Disabled', value='disabled')
-NEST_ALL_UPSTREAMS: list[SelectOptionDict] = [NEST_NULL_UPSTREAM] + _format_options({
-    'Wibeee Nest': NEST_DEFAULT_UPSTREAM,
-    'SolarProfit': 'http://wdata.solarprofit.es:8080',
-})
+NEST_PROXY_DISABLED: str = 'proxy_disabled'
+NEST_NULL_UPSTREAM: str = 'proxy_null'
+NEST_ALL_UPSTREAMS: list[SelectOptionDict] = [SelectOptionDict(label='Disabled (polling only)', value=NEST_PROXY_DISABLED),
+                                              SelectOptionDict(label='Local only (no Cloud)', value=NEST_NULL_UPSTREAM)] + \
+                                             _format_options({
+                                                 'Wibeee Nest': NEST_DEFAULT_UPSTREAM,
+                                                 'SolarProfit': 'http://wdata.solarprofit.es:8080',
+                                             })

--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+from homeassistant.helpers.selector import SelectOptionDict
+
 DOMAIN = 'wibeee'
 NEST_DEFAULT_UPSTREAM = 'http://nest-ingest.wibeee.com'
 PROXY_PORT = 8600
@@ -8,10 +10,15 @@ DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
 DEFAULT_TIMEOUT = timedelta(seconds=10)
 
 CONF_NEST_PROXY_ENABLE = 'nest_proxy_enable'
-CONF_NEST_PROXY_PORT = 'nest_proxy_port'
 CONF_NEST_UPSTREAM = 'nest_upstream'
 
-NEST_UPSTREAMS = [
-    'http://nest-ingest.wibeee.com',
-    'http://wdata.solarprofit.es:8080'
-]
+
+def _format_options(upstreams: dict[str, str]) -> list[SelectOptionDict]:
+    return [SelectOptionDict(label=f'{cloud} ({url})', value=url) for cloud, url in upstreams.items()]
+
+
+NEST_NULL_UPSTREAM: SelectOptionDict = SelectOptionDict(label='Disabled', value='disabled')
+NEST_ALL_UPSTREAMS: list[SelectOptionDict] = [NEST_NULL_UPSTREAM] + _format_options({
+    'Wibeee Nest': NEST_DEFAULT_UPSTREAM,
+    'SolarProfit': 'http://wdata.solarprofit.es:8080',
+})

--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -63,13 +63,9 @@ async def get_nest_proxy(
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_session)
 
-    def nest_forward(decode_data: Callable[[web.Request, Optional[str]], Awaitable[Tuple[str, Dict]]]) -> _HandlerType:
+    def nest_forward(decode_data: Callable[[web.Request], Awaitable[Tuple[str, Dict]]]) -> _HandlerType:
         async def handler(req: web.Request) -> web.StreamResponse:
-            # Wibeee sometimes sends garbage that we can't parse. capture that rubbish
-            # here so that we can send it off to Wibeee Cloud when forwarding below.
-            req_body = (await req.text()) if req.can_read_body else None
-
-            mac_addr, push_data = await decode_data(req, req_body)
+            mac_addr, push_data = await decode_data(req)
             device_info = nest_proxy.get_device_info(mac_addr)
 
             if device_info is None:
@@ -86,8 +82,8 @@ async def get_nest_proxy(
 
             url = f'{device_info.upstream}{req.path_qs}'
             try:
-                LOGGER.debug("Forwarding push data from %s using %s %s: %s", mac_addr, req.method, url, req_body)
-                res = await session.request(req.method, url, data=None if req.path == req.path_qs else json.dumps(push_data))
+                LOGGER.debug("Forwarding push data from %s using %s %s: %s", mac_addr, req.method, url, push_data)
+                res = await session.request(req.method, url, json=push_data if req.can_read_body else None)
                 res_body = await res.read()
                 if res.status < 200 or res.status > 299:
                     LOGGER.warning('Wibeee Cloud returned %d for forwarded request: %s', res.status, res_body)
@@ -128,14 +124,15 @@ async def get_nest_proxy(
     return nest_proxy
 
 
-async def extract_query_params(req: web.Request, body: Optional[str]) -> Tuple[str, Dict]:
+async def extract_query_params(req: web.Request) -> Tuple[str, Dict]:
     """Extracts Wibeee data from query params."""
     query = {k: v for k, v in parse_qsl(req.query_string)}
     return query['mac'], query
 
 
-async def extract_json_body(req: web.Request, body: Optional[str]) -> Tuple[Optional[str], Dict]:
+async def extract_json_body(req: web.Request) -> Tuple[Optional[str], Dict]:
     """Extracts Wibeee data from JSON request body."""
+    body = await req.text() if req.can_read_body else {}
     LOGGER.debug("Parsing JSON in %s %s", req.method, req.path, body)
     parsed_body = None
     parse_error = None

--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qsl
 
 from homeassistant.components.network import async_get_source_ip
 from homeassistant.components.network.const import PUBLIC_TARGET_IP
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers import singleton
 from homeassistant.helpers.typing import EventType
@@ -17,6 +18,12 @@ from aiohttp.web_routedef import _HandlerType
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.core import HomeAssistant
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+from .const import (
+    CONF_NEST_PROXY_PORT,
+    CONF_NEST_UPSTREAM_URL,
+    CONF_NEST_UPSTREAM_PORT
+)
 
 
 class NestProxy(object):
@@ -38,11 +45,12 @@ class NestProxy(object):
 @singleton.singleton("wibeee_nest_proxy")
 async def get_nest_proxy(
         hass: HomeAssistant,
-        upstream='http://nest-ingest.wibeee.com',
-        local_port=8600,
+        entry: ConfigEntry
 ) -> NestProxy:
     session = async_get_clientsession(hass)
     nest_proxy = NestProxy()
+    upstream = entry.options.get(CONF_NEST_UPSTREAM_URL) + ':' + str(entry.options.get(CONF_NEST_UPSTREAM_PORT))
+    local_port = entry.options.get(CONF_NEST_PROXY_PORT)
 
     def nest_forward(snoop_data: Callable[[web.Request], Tuple[str, Dict]] = None) -> _HandlerType:
         async def handler(req: web.Request) -> web.StreamResponse:

--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -82,7 +82,7 @@ async def get_nest_proxy(
             url = f'{device_info.upstream}{req.path_qs}'
             req_body = (await req.read()) if req.can_read_body else None
 
-            res = await session.request(req.method, url, data=req_body, headers=req.headers)
+            res = await session.request(req.method, url, data=req_body)
             res_body = await res.read()
             if res.status != 200:
                 LOGGER.warning('Wibeee Cloud returned %d: %s', res.status, res_body)

--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -4,7 +4,6 @@ from urllib.parse import parse_qsl
 
 from homeassistant.components.network import async_get_source_ip
 from homeassistant.components.network.const import PUBLIC_TARGET_IP
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers import singleton
 from homeassistant.helpers.typing import EventType
@@ -19,18 +18,16 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.core import HomeAssistant
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-from .const import (
-    CONF_NEST_PROXY_PORT,
-    CONF_NEST_UPSTREAM_URL,
-    CONF_NEST_UPSTREAM_PORT
-)
-
 
 class NestProxy(object):
     _listeners = {}
+    upstream = None
+    local_port = None
 
-    def register_device(self, mac_address: str, listener: Callable[[Dict], None]):
+    def register_device(self, mac_address: str, listener: Callable[[Dict], None], upstream: str, local_port: int):
         self._listeners[mac_address] = listener
+        self.upstream = upstream
+        self.local_port = local_port
 
     def unregister_device(self, mac_address: str):
         self._listeners.pop(mac_address)
@@ -44,17 +41,14 @@ class NestProxy(object):
 
 @singleton.singleton("wibeee_nest_proxy")
 async def get_nest_proxy(
-        hass: HomeAssistant,
-        entry: ConfigEntry
+        hass: HomeAssistant
 ) -> NestProxy:
     session = async_get_clientsession(hass)
     nest_proxy = NestProxy()
-    upstream = entry.options.get(CONF_NEST_UPSTREAM_URL) + ':' + str(entry.options.get(CONF_NEST_UPSTREAM_PORT))
-    local_port = entry.options.get(CONF_NEST_PROXY_PORT)
 
     def nest_forward(snoop_data: Callable[[web.Request], Tuple[str, Dict]] = None) -> _HandlerType:
         async def handler(req: web.Request) -> web.StreamResponse:
-            url = f'{upstream}{req.path}?{req.query_string}'
+            url = f'{nest_proxy.upstream}{req.path}?{req.query_string}'
             req_body = (await req.read()) if req.can_read_body else None
 
             res = await session.request(req.method, url, data=req_body)
@@ -86,8 +80,8 @@ async def get_nest_proxy(
     access_log = logging.getLogger(f'{__name__}.access')
     access_log.setLevel(access_log.getEffectiveLevel() + 10)
 
-    server = hass.loop.create_task(web._run_app(app, host=local_ip, port=local_port, access_log=access_log))
-    LOGGER.info('Wibeee Nest proxy listening on http://%s:%d', local_ip, local_port)
+    server = hass.loop.create_task(web._run_app(app, host=local_ip, port=nest_proxy.local_port, access_log=access_log))
+    LOGGER.info('Wibeee Nest proxy listening on http://%s:%d', local_ip, nest_proxy.local_port)
 
     @callback
     def shutdown_proxy(ev: EventType) -> None:

--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -17,7 +17,6 @@ import aiohttp
 from aiohttp import web
 from aiohttp.web_routedef import _HandlerType
 
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.core import HomeAssistant
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
@@ -50,8 +49,19 @@ async def get_nest_proxy(
         hass: HomeAssistant,
         local_port=8600,
 ) -> NestProxy:
-    session = async_get_clientsession(hass)
     nest_proxy = NestProxy()
+
+    # disable persistent HTTP connections as the Wibeee Cloud will otherwise
+    # time out our connections, causing a ServerDisconnectedError below.
+    connector = aiohttp.TCPConnector(force_close=True)
+    session = aiohttp.ClientSession(connector=connector)
+
+    @callback
+    def close_session(ev: EventType) -> None:
+        session.detach()
+        connector.close()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_session)
 
     def nest_forward(decode_data: Callable[[web.Request], Awaitable[Tuple[str, Dict]]]) -> _HandlerType:
         async def handler(req: web.Request) -> web.StreamResponse:

--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -75,7 +75,7 @@ async def get_nest_proxy(
             res = await session.request(req.method, url, data=req_body, headers=req.headers)
             res_body = await res.read()
             if res.status != 200:
-                LOGGER.error('Wibeee Cloud returned %d: %s', res.status, res_body)
+                LOGGER.warning('Wibeee Cloud returned %d: %s', res.status, res_body)
 
             return web.Response(headers=res.headers, body=res_body)
 
@@ -124,7 +124,7 @@ async def extract_json_body(req: web.Request) -> Tuple[Optional[str], Dict]:
         return body.get('mac', None), body
 
     except json.decoder.JSONDecodeError as e:
-        LOGGER.error("Error parsing JSON in %s %s: %s", req.method, req.path, body, exc_info=e)
+        LOGGER.debug("Error parsing JSON in %s %s: %s", req.method, req.path, body, exc_info=e)
         return None, {}
 
 

--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Dict, Tuple
+from typing import Callable, Dict, Tuple, NamedTuple, Awaitable
 from urllib.parse import parse_qsl
 
 from homeassistant.components.network import async_get_source_ip
@@ -7,6 +7,8 @@ from homeassistant.components.network.const import PUBLIC_TARGET_IP
 from homeassistant.core import callback
 from homeassistant.helpers import singleton
 from homeassistant.helpers.typing import EventType
+
+from const import NEST_NULL_UPSTREAM
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,58 +21,68 @@ from homeassistant.core import HomeAssistant
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 
-class NestProxy(object):
-    _listeners = {}
-    upstream = None
-    local_port = None
+class DeviceConfig(NamedTuple):
+    handle_push_data: Callable[[Dict], None]
+    """Callback that will receive push data."""
+    upstream: str
+    """The upstream server to forward data to"""
 
-    def register_device(self, mac_address: str, listener: Callable[[Dict], None], upstream: str, local_port: int):
-        self._listeners[mac_address] = listener
-        self.upstream = upstream
-        self.local_port = local_port
+
+class NestProxy(object):
+    _listeners: Dict[str, DeviceConfig] = {}
+
+    def register_device(self, mac_address: str, push_data_listener: Callable[[Dict], None], upstream: str):
+        self._listeners[mac_address] = DeviceConfig(
+            handle_push_data=push_data_listener,
+            upstream=upstream
+        )
 
     def unregister_device(self, mac_address: str):
         self._listeners.pop(mac_address)
 
-    def dispatch(self, mac_addr: str, pushed_data: Dict):
-        if mac_addr in self._listeners:
-            self._listeners[mac_addr](pushed_data)
-        else:
-            LOGGER.debug("Ignoring pushed data from %s: %s", mac_addr, pushed_data)
+    def get_device_info(self, mac_addr: str) -> DeviceConfig:
+        return self._listeners.get(mac_addr, None)
 
 
 @singleton.singleton("wibeee_nest_proxy")
 async def get_nest_proxy(
-        hass: HomeAssistant
+        hass: HomeAssistant,
+        local_port=8600,
 ) -> NestProxy:
     session = async_get_clientsession(hass)
     nest_proxy = NestProxy()
 
-    def nest_forward(snoop_data: Callable[[web.Request], Tuple[str, Dict]] = None) -> _HandlerType:
+    def nest_forward(decode_data: Callable[[web.Request], Awaitable[Tuple[str, Dict]]]) -> _HandlerType:
         async def handler(req: web.Request) -> web.StreamResponse:
-            url = f'{nest_proxy.upstream}{req.path}?{req.query_string}'
+            mac_addr, push_data = await decode_data(req)
+            device_info = nest_proxy.get_device_info(mac_addr)
+
+            if device_info is None:
+                LOGGER.debug("Ignoring pushed data from %s: %s", mac_addr, push_data)
+                return web.Response(status=403)
+
+            device_info.handle_push_data(push_data)
+
+            if device_info.upstream == NEST_NULL_UPSTREAM['value']:
+                # don't send to any upstream.
+                return web.Response(status=200)
+
+            url = f'{device_info.upstream}{req.path_qs}'
             req_body = (await req.read()) if req.can_read_body else None
 
             res = await session.request(req.method, url, data=req_body)
             res_body = await res.read()
 
-            if snoop_data:
-                mac_addr, push_data = snoop_data(req)
-                nest_proxy.dispatch(mac_addr, push_data)
-
             return web.Response(headers=res.headers, body=res_body)
 
         return handler
 
-    def extract_query_params(req: web.Request) -> Tuple[str, Dict]:
-        """Extracts Wibeee data from query params."""
-        query = {k: v for k, v in parse_qsl(req.query_string)}
-        return query['mac'], query
-
     app = aiohttp.web.Application()
     app.add_routes([
         web.get('/Wibeee/receiverLeap', nest_forward(extract_query_params)),
-        web.route('*', '/{anypath:.*}', nest_forward()),
+        web.get('/Wibeee/receiverAvg', nest_forward(extract_query_params)),
+        web.get('/Wibeee/receiverJSON', nest_forward(extract_json_body)),
+        web.route('*', '/{anypath:.*}', unknown_path_handler),
     ])
 
     # don't listen on public IP
@@ -80,8 +92,8 @@ async def get_nest_proxy(
     access_log = logging.getLogger(f'{__name__}.access')
     access_log.setLevel(access_log.getEffectiveLevel() + 10)
 
-    server = hass.loop.create_task(web._run_app(app, host=local_ip, port=nest_proxy.local_port, access_log=access_log))
-    LOGGER.info('Wibeee Nest proxy listening on http://%s:%d', local_ip, nest_proxy.local_port)
+    server = hass.loop.create_task(web._run_app(app, host=local_ip, port=local_port, access_log=access_log))
+    LOGGER.info('Wibeee Nest proxy listening on http://%s:%d', local_ip, local_port)
 
     @callback
     def shutdown_proxy(ev: EventType) -> None:
@@ -90,3 +102,20 @@ async def get_nest_proxy(
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown_proxy)
     return nest_proxy
+
+
+async def extract_query_params(req: web.Request) -> Tuple[str, Dict]:
+    """Extracts Wibeee data from query params."""
+    query = {k: v for k, v in parse_qsl(req.query_string)}
+    return query['mac'], query
+
+
+async def extract_json_body(req: web.Request) -> Tuple[str, Dict]:
+    """Extracts Wibeee data from JSON request body."""
+    body = await req.json()
+    return body.mac, body
+
+
+async def unknown_path_handler(req: web.Request) -> web.StreamResponse:
+    LOGGER.warning('Unable to handle request to %s', req.path)
+    pass

--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -8,7 +8,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import singleton
 from homeassistant.helpers.typing import EventType
 
-from const import NEST_NULL_UPSTREAM
+from .const import NEST_NULL_UPSTREAM
 
 LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ async def get_nest_proxy(
 
             device_info.handle_push_data(push_data)
 
-            if device_info.upstream == NEST_NULL_UPSTREAM['value']:
+            if device_info.upstream == NEST_NULL_UPSTREAM:
                 # don't send to any upstream.
                 return web.Response(status=200)
 
@@ -80,8 +80,6 @@ async def get_nest_proxy(
     app = aiohttp.web.Application()
     app.add_routes([
         web.get('/Wibeee/receiverLeap', nest_forward(extract_query_params)),
-        web.get('/Wibeee/receiverAvg', nest_forward(extract_query_params)),
-        web.get('/Wibeee/receiverJSON', nest_forward(extract_json_body)),
         web.route('*', '/{anypath:.*}', unknown_path_handler),
     ])
 
@@ -117,5 +115,5 @@ async def extract_json_body(req: web.Request) -> Tuple[str, Dict]:
 
 
 async def unknown_path_handler(req: web.Request) -> web.StreamResponse:
-    LOGGER.warning('Unable to handle request to %s', req.path)
-    pass
+    LOGGER.debug("Ignoring pushed data to unknown path %s", req.path)
+    return web.Response(status=200)

--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -1,4 +1,5 @@
 import json
+import re
 import logging
 from typing import Callable, Dict, Tuple, NamedTuple, Awaitable, Optional
 from urllib.parse import parse_qsl
@@ -63,31 +64,39 @@ async def get_nest_proxy(
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_session)
 
-    def nest_forward(decode_data: Callable[[web.Request], Awaitable[Tuple[str, Dict]]]) -> _HandlerType:
+    def nest_forward(decode_data: Callable[[web.Request, Optional[str]], Awaitable[Tuple[str, Dict]]]) -> _HandlerType:
         async def handler(req: web.Request) -> web.StreamResponse:
-            mac_addr, push_data = await decode_data(req)
+            # Wibeee sometimes sends garbage that we can't parse. capture that rubbish
+            # here so that we can send it off to Wibeee Cloud when forwarding below.
+            req_body = (await req.text()) if req.can_read_body else None
+
+            mac_addr, push_data = await decode_data(req, req_body)
             device_info = nest_proxy.get_device_info(mac_addr)
 
             if device_info is None:
-                LOGGER.debug("Ignoring unexpected push data from %s in %s %s: %s", mac_addr, req.method, req.path, push_data)
+                LOGGER.debug("Ignoring unexpected push data from %s received as %s %s: %s", mac_addr, req.method, req.path, push_data)
                 return web.Response(status=200)
 
+            LOGGER.debug("Updating sensors using push data from %s received as %s %s: %s", mac_addr, req.method, req.path, push_data)
             device_info.handle_push_data(push_data)
 
             if device_info.upstream == NEST_NULL_UPSTREAM:
                 # don't send to any upstream.
-                LOGGER.debug("Processing local-only push data from %s in %s %s: %s", mac_addr, req.method, req.path, push_data)
                 return web.Response(status=200)
 
             url = f'{device_info.upstream}{req.path_qs}'
-            req_body = (await req.read()) if req.can_read_body else None
+            try:
+                LOGGER.debug("Forwarding push data from %s using %s %s: %s", mac_addr, req.method, url, req_body)
+                res = await session.request(req.method, url, data=req_body)
+                res_body = await res.read()
+                if res.status != 200:
+                    LOGGER.error('Wibeee Cloud returned %d for forwarded request: %s', res.status, res_body)
 
-            res = await session.request(req.method, url, data=req_body, headers=req.headers)
-            res_body = await res.read()
-            if res.status != 200:
-                LOGGER.error('Wibeee Cloud returned %d: %s', res.status, res_body)
+                return web.Response(status=res.status, headers=res.headers, body=res_body)
 
-            return web.Response(headers=res.headers, body=res_body)
+            except aiohttp.ClientError as e:
+                LOGGER.error('Wibeee Cloud HTTP error during %d %s', req.method, req.path, exc_info=e)
+                return web.Response(status=200)
 
         return handler
 
@@ -119,21 +128,27 @@ async def get_nest_proxy(
     return nest_proxy
 
 
-async def extract_query_params(req: web.Request) -> Tuple[str, Dict]:
+async def extract_query_params(req: web.Request, body: Optional[str]) -> Tuple[str, Dict]:
     """Extracts Wibeee data from query params."""
     query = {k: v for k, v in parse_qsl(req.query_string)}
     return query['mac'], query
 
 
-async def extract_json_body(req: web.Request) -> Tuple[Optional[str], Dict]:
+async def extract_json_body(req: web.Request, body: Optional[str]) -> Tuple[Optional[str], Dict]:
     """Extracts Wibeee data from JSON request body."""
-    body = (await req.text()) if req.can_read_body else None
     LOGGER.debug("Parsing JSON in %s %s", req.method, req.path, body)
     try:
-        body = json.loads(body)
+        body = {} if body is None else json.loads(body)
         return body.get('mac', None), body
 
     except json.decoder.JSONDecodeError as e:
+        # Wibeee will send invalid JSON at times. make a last-ditch attempt to extract the
+        # MAC address so that the forwarding code can work out what upstream to send it to.
+        m = re.match('^{"mac":"(\\w{12})"', body)
+        if m:
+            LOGGER.debug("Worked around invalid JSON in %s %s: %s", req.method, req.path, body, exc_info=e)
+            return m[1], {}
+
         LOGGER.error("Error parsing JSON in %s %s: %s", req.method, req.path, body, exc_info=e)
         return None, {}
 

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -51,8 +51,8 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_TIMEOUT,
     CONF_NEST_PROXY_ENABLE,
-    CONF_NEST_PROXY_PORT,
-    CONF_NEST_UPSTREAM
+    CONF_NEST_UPSTREAM,
+    NEST_DEFAULT_UPSTREAM,
 )
 from .nest import get_nest_proxy
 from .util import short_mac
@@ -184,9 +184,9 @@ async def async_setup_local_push(hass: HomeAssistant, entry: ConfigEntry, device
     def unregister_listener():
         nest_proxy.unregister_device(mac_address)
 
-    upstream = entry.options.get(CONF_NEST_UPSTREAM)
-    local_port = entry.options.get(CONF_NEST_PROXY_PORT)
-    nest_proxy.register_device(mac_address, on_pushed_data, upstream, local_port)
+    # default to Wibeee Nest for entries saved by previous versions
+    upstream = entry.options.get(CONF_NEST_UPSTREAM, NEST_DEFAULT_UPSTREAM)
+    nest_proxy.register_device(mac_address, on_pushed_data, upstream)
     return unregister_listener
 
 

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -200,9 +200,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     if use_nest_proxy:
         # first set up the Nest proxy. it's important to do this first because the device will not respond to status.xml
         # calls if it is unable to push data up to Wibeee Nest, causing this integration to fail at start-up.
-        await get_nest_proxy(
-            hass
-        )
+        await get_nest_proxy(hass)
 
     api = WibeeeAPI(session, host, min(timeout, scan_interval))
     device = await api.async_fetch_device_info(retries=5)

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -52,8 +52,7 @@ from .const import (
     DEFAULT_TIMEOUT,
     CONF_NEST_PROXY_ENABLE,
     CONF_NEST_PROXY_PORT,
-    CONF_NEST_UPSTREAM_URL,
-    CONF_NEST_UPSTREAM_PORT
+    CONF_NEST_UPSTREAM
 )
 from .nest import get_nest_proxy
 from .util import short_mac
@@ -185,7 +184,7 @@ async def async_setup_local_push(hass: HomeAssistant, entry: ConfigEntry, device
     def unregister_listener():
         nest_proxy.unregister_device(mac_address)
 
-    upstream = entry.options.get(CONF_NEST_UPSTREAM_URL) + ':' + str(entry.options.get(CONF_NEST_UPSTREAM_PORT))
+    upstream = entry.options.get(CONF_NEST_UPSTREAM)
     local_port = entry.options.get(CONF_NEST_PROXY_PORT)
     nest_proxy.register_device(mac_address, on_pushed_data, upstream, local_port)
     return unregister_listener

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -171,9 +171,7 @@ def setup_local_polling(hass: HomeAssistant, api: WibeeeAPI, sensors: list['Wibe
 
 async def async_setup_local_push(hass: HomeAssistant, entry: ConfigEntry, device, sensors: list['WibeeeSensor']):
     mac_address = device['macAddr']
-    nest_proxy = await get_nest_proxy(
-        hass
-    )
+    nest_proxy = await get_nest_proxy(hass)
 
     def nest_push_param(s: WibeeeSensor) -> str:
         return s.nest_push_param
@@ -184,8 +182,7 @@ async def async_setup_local_push(hass: HomeAssistant, entry: ConfigEntry, device
     def unregister_listener():
         nest_proxy.unregister_device(mac_address)
 
-    # default to Wibeee Nest for entries saved by previous versions
-    upstream = entry.options.get(CONF_NEST_UPSTREAM, NEST_DEFAULT_UPSTREAM)
+    upstream = entry.options.get(CONF_NEST_UPSTREAM)
     nest_proxy.register_device(mac_address, on_pushed_data, upstream)
     return unregister_listener
 

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -50,9 +50,9 @@ from .const import (
     DOMAIN,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_TIMEOUT,
-    CONF_NEST_PROXY_ENABLE,
     CONF_NEST_UPSTREAM,
     NEST_DEFAULT_UPSTREAM,
+    NEST_PROXY_DISABLED,
 )
 from .nest import get_nest_proxy
 from .util import short_mac
@@ -198,7 +198,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     host = entry.data[CONF_HOST]
     scan_interval = timedelta(seconds=entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL.total_seconds()))
     timeout = timedelta(seconds=entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT.total_seconds()))
-    use_nest_proxy = entry.options.get(CONF_NEST_PROXY_ENABLE)
+    use_nest_proxy = entry.options.get(CONF_NEST_UPSTREAM, NEST_PROXY_DISABLED) != NEST_PROXY_DISABLED
 
     if use_nest_proxy:
         # first set up the Nest proxy. it's important to do this first because the device will not respond to status.xml

--- a/custom_components/wibeee/translations/en.json
+++ b/custom_components/wibeee/translations/en.json
@@ -21,19 +21,10 @@
     "step": {
       "init": {
         "title": "Wibeee integration options",
-        "description": "Customize the integration.",
+        "description": "Configure Polling and and Local Push",
         "data": {
-          "scan_interval": "Device polling interval in seconds.",
-          "nest_proxy_enable": "Enable Nest Proxy",
-          "nest_upstream_url": "URL of the Nest upstream",
-          "nest_upstream_port": "Port of the Nest upstream"
-        }
-      },
-      "configure_upstream": {
-        "title": "Configure Nest Cloud service",
-        "description": "Optionally choose which Cloud to upload Wibeee data to.",
-        "data": {
-          "nest_upstream": "Nest Cloud service"
+          "scan_interval": "Device polling interval in seconds",
+          "nest_upstream": "Nest Cloud service to use"
         }
       }
     }

--- a/custom_components/wibeee/translations/en.json
+++ b/custom_components/wibeee/translations/en.json
@@ -25,9 +25,15 @@
         "data": {
           "scan_interval": "Device polling interval in seconds.",
           "nest_proxy_enable": "Enable Nest Proxy",
-          "nest_proxy_port": "Nest Proxy port",
           "nest_upstream_url": "URL of the Nest upstream",
           "nest_upstream_port": "Port of the Nest upstream"
+        }
+      },
+      "configure_upstream": {
+        "title": "Configure Nest Cloud service",
+        "description": "Optionally choose which Cloud to upload Wibeee data to.",
+        "data": {
+          "nest_upstream": "Nest Cloud service"
         }
       }
     }

--- a/custom_components/wibeee/translations/en.json
+++ b/custom_components/wibeee/translations/en.json
@@ -24,7 +24,10 @@
         "description": "Customize the integration.",
         "data": {
           "scan_interval": "Device polling interval in seconds.",
-          "nest_proxy_enable": "Enable Nest Proxy on port 8600"
+          "nest_proxy_enable": "Enable Nest Proxy",
+          "nest_proxy_port": "Nest Proxy port",
+          "nest_upstream_url": "URL of the Nest upstream",
+          "nest_upstream_port": "Port of the Nest upstream"
         }
       }
     }

--- a/custom_components/wibeee/translations/en.json
+++ b/custom_components/wibeee/translations/en.json
@@ -24,7 +24,7 @@
         "description": "Configure Polling and and Local Push",
         "data": {
           "scan_interval": "Device polling interval in seconds",
-          "nest_upstream": "Nest Cloud service to use"
+          "nest_upstream": "Cloud service to upload data to"
         }
       }
     }


### PR DESCRIPTION
Allows selecting a different Cloud service to upload. Also introduces Local-only mode for those who want to use Local Push without sending the data off to any Cloud service.

![Wibeee options](https://github.com/luuuis/hass_wibeee/assets/161006/4078ec9c-7a79-48a2-a361-1ece8c263433)

When running the new version for the first time the `ConfigEntry` is migrated to version 2 to support the new configuration select box.