### PR TITLE
fix(nest): fixed local push not enabled

### DIFF
--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -191,8 +191,8 @@ def setup_local_polling(hass: HomeAssistant, api: WibeeeAPI, device: DeviceInfo,
     return async_track_time_interval(hass, fetching_data, scan_interval)
 
 
-async def async_setup_local_push(hass: HomeAssistant, entry: ConfigEntry, device, sensors: list['WibeeeSensor']):
-    mac_address = device['macAddr']
+async def async_setup_local_push(hass: HomeAssistant, entry: ConfigEntry, device: DeviceInfo, sensors: list['WibeeeSensor']):
+    mac_address = device.macAddr
     nest_proxy = await get_nest_proxy(hass)
 
     def nest_push_param(s: WibeeeSensor) -> str:


### PR DESCRIPTION
Removed stray `device['macAddr']` reference that was inadvertently left behind when introducing new `DeviceInfo` class, which causes an error when setting up the integration.

```
Error while setting up wibeee platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 359, in _async_setup_platform
    await asyncio.shield(task)
  File "/config/custom_components/wibeee/sensor.py", line 247, in async_setup_entry
    remove_push_listener = await async_setup_local_push(hass, entry, device, sensors)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/wibeee/sensor.py", line 195, in async_setup_local_push
    mac_address = device['macAddr']
                  ~~~~~~^^^^^^^^^^^
TypeError: tuple indices must be integers or slices, not str
```