### PR TITLE
fix(logging): mask values2.xml secrets

### DIFF
--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -169,7 +169,7 @@ def get_status_elements(device: DeviceInfo) -> list[StatusElement]:
 
 def update_sensors(sensors, update_source, lookup_key, data):
     sensors_with_updates = [s for s in sensors if lookup_key(s) in data]
-    _LOGGER.debug('Received %d sensor values from %s: %s', len(sensors_with_updates), update_source, data, sensors_with_updates)
+    _LOGGER.debug('Received %d sensor values from %s: %s', len(sensors_with_updates), update_source, data)
     for s in sensors_with_updates:
         value = data.get(lookup_key(s))
         s.update_value(value, update_source)

--- a/custom_components/wibeee/util.py
+++ b/custom_components/wibeee/util.py
@@ -1,3 +1,22 @@
+import re
+
+
 def short_mac(mac_addr):
     """Returns the last 6 chars of the MAC address for showing in UI."""
     return mac_addr.replace(':', '')[-6:].upper()
+
+
+def scrub_xml_text_naively(keys: list[str], xml_text: str) -> str:
+    """Naively use a RegEx (facepalm) to scrub values from XML text."""
+    scrubbed_text = re.sub(f'<({"|".join(keys)})>.*?</\\1>', f'<\\1>*MASKED*</\\1>', xml_text)
+    return scrubbed_text
+
+
+def scrub_dict_top_level(keys: list[str], values: dict) -> dict:
+    """Scrubs values from """
+    scrubbed_values = dict(values)
+    for scrub_key in keys:
+        if scrub_key in values:
+            scrubbed_values.update({scrub_key: '*MASKED*'})
+
+    return scrubbed_values


### PR DESCRIPTION
Wibeee's `values2.xml` API is returning WiFi secrets willy-nilly. Attempt to mask them out of log messages and returned dict to prevent downstream leakage.