### PR TITLE
chore: relax lxml requirement for compatibility with older HA

### DIFF
--- a/custom_components/wibeee/manifest.json
+++ b/custom_components/wibeee/manifest.json
@@ -14,7 +14,7 @@
   "issue_tracker": "https://github.com/luuuis/hass_wibeee/issues",
   "requirements": [
     "xmltodict==0.13.0",
-    "lxml==5.1.0"
+    "lxml>=4.9.1,<6"
   ],
   "version": "3.4.3"
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -1615,4 +1615,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "2f988e5010f4e512cafe7a540a875ec247fd944b13f3211f560961ddcd44628e"
+content-hash = "39a701c1f23ffe16e04f6508737e176739d029dadd672cab9b75649069b8223f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 python = ">=3.11,<3.13"
 homeassistant = "2023.7.3"
 xmltodict = "0.13.0"
-lxml = "5.1.0"
+lxml = ">=4.9.1,<6"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"


### PR DESCRIPTION
Prior to 2024.2.0 we can't use lxml 5.x yet.

```
2024-02-14 09:45:25.793 ERROR (SyncWorker_3) [homeassistant.util.package] Unable to install package lxml==5.1.0: ERROR: Cannot install lxml==5.1.0 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
2024-02-14 09:45:35.037 ERROR (SyncWorker_3) [homeassistant.util.package] Unable to install package lxml==5.1.0: ERROR: Cannot install lxml==5.1.0 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
2024-02-14 09:45:43.460 ERROR (SyncWorker_3) [homeassistant.util.package] Unable to install package lxml==5.1.0: ERROR: Cannot install lxml==5.1.0 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
2024-02-14 09:45:43.462 ERROR (MainThread) [homeassistant.setup] Setup failed for custom integration 'wibeee': Requirements for wibeee not found: ['lxml==5.1.0'].
```