### PR TITLE
feat: add Active Energy Consumed/Produced sensors

### DIFF
--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -103,6 +103,8 @@ KNOWN_SENSORS = [
     SensorType('pap', 'p', 'Apparent_Power', 'Apparent Power', POWER_VOLT_AMPERE, SensorDeviceClass.APPARENT_POWER),
     SensorType('fpot', 'f', 'Power_Factor', 'Power Factor', None, SensorDeviceClass.POWER_FACTOR),
     SensorType('eac', 'e', 'Active_Energy', 'Active Energy', ENERGY_WATT_HOUR, SensorDeviceClass.ENERGY),
+    SensorType('eaccons', 'e', 'Active_Energy_Consumed', 'Active Energy Consumed', ENERGY_WATT_HOUR, SensorDeviceClass.ENERGY),
+    SensorType('eacprod', 'e', 'Active_Energy_Produced', 'Active Energy Produced', ENERGY_WATT_HOUR, SensorDeviceClass.ENERGY),
     SensorType('ereact', 'o', 'Inductive_Reactive_Energy', 'Inductive Reactive Energy', ENERGY_VOLT_AMPERE_REACTIVE_HOUR, SensorDeviceClass.ENERGY),
     SensorType('ereactc', None, 'Capacitive_Reactive_Energy', 'Capacitive Reactive Energy', ENERGY_VOLT_AMPERE_REACTIVE_HOUR, SensorDeviceClass.ENERGY),
 ]


### PR DESCRIPTION
Recognise the `eacprodX` and `eacconsX` values that some device/firmware combinations are using (see #80).

```xml
<?xml version="1.0" encoding="UTF-8"?>

<values>
    <variable>
        <id>eac1</id>
        <value>0</value>
    </variable>
    <variable>
        <id>eacprod1</id>
        <value>36514</value>
    </variable>
    <variable>
        <id>eaccons1</id>
        <value>28442</value>
    </variable>
</values>
```