### PR TITLE
fix: emulate Nest Cloud responses in Local-only mode

### DIFF
--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -8,8 +8,7 @@ from homeassistant.components.network.const import PUBLIC_TARGET_IP
 from homeassistant.core import callback
 from homeassistant.helpers import singleton
 from homeassistant.helpers.typing import EventType
-
-from .const import NEST_NULL_UPSTREAM
+from wibeee.const import NEST_NULL_UPSTREAM
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,33 +39,24 @@ class NestProxy(object):
     def unregister_device(self, mac_address: str):
         self._listeners.pop(mac_address)
 
-    def get_device_info(self, mac_addr: str) -> DeviceConfig:
+    def get_device_info(self, mac_addr: str) -> DeviceConfig | None:
         return self._listeners.get(mac_addr, None)
 
 
-@singleton.singleton("wibeee_nest_proxy")
-async def get_nest_proxy(
-        hass: HomeAssistant,
-        local_port=8600,
-) -> NestProxy:
-    nest_proxy = NestProxy()
-
+def create_application(get_device_info: Callable[[str], Optional[DeviceConfig]]) -> aiohttp.web.Application:
     # disable persistent HTTP connections as the Wibeee Cloud will otherwise
     # time out our connections, causing a ServerDisconnectedError below.
     connector = aiohttp.TCPConnector(force_close=True)
     session = aiohttp.ClientSession(connector=connector)
 
-    @callback
-    def close_session(ev: EventType) -> None:
+    async def close_session(app: web.Application) -> None:
         session.detach()
-        connector.close()
+        await connector.close()
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_session)
-
-    def nest_forward(decode_data: Callable[[web.Request], Awaitable[Tuple[str, Dict]]]) -> _HandlerType:
+    def nest_forward(decode_data: Callable[[web.Request], Awaitable[Tuple[str, Dict, str]]]) -> _HandlerType:
         async def handler(req: web.Request) -> web.StreamResponse:
             mac_addr, push_data, forward_body = await decode_data(req)
-            device_info = nest_proxy.get_device_info(mac_addr)
+            device_info = get_device_info(mac_addr)
 
             if device_info is None:
                 LOGGER.debug("Ignoring unexpected push data from %s received as %s %s: %s", mac_addr, req.method, req.path, push_data)
@@ -98,6 +88,7 @@ async def get_nest_proxy(
         return handler
 
     app = aiohttp.web.Application()
+    app.on_shutdown.append(close_session)
     app.add_routes([
         web.get('/Wibeee/receiver', nest_forward(extract_query_params)),
         web.get('/Wibeee/receiverAvg', nest_forward(extract_query_params)),
@@ -107,13 +98,20 @@ async def get_nest_proxy(
         web.route('*', '/{anypath:.*}', unknown_path_handler),
     ])
 
-    # don't listen on public IP
-    local_ip = await async_get_source_ip(hass, target_ip=PUBLIC_TARGET_IP)
+    return app
 
+
+@singleton.singleton("wibeee_nest_proxy")
+async def get_nest_proxy(hass: HomeAssistant, local_port=8600) -> NestProxy:
     # access log only if DEBUG level is enabled
     access_log = logging.getLogger(f'{__name__}.access')
     access_log.setLevel(access_log.getEffectiveLevel() + 10)
 
+    # don't listen on public IP
+    local_ip = await async_get_source_ip(hass, target_ip=PUBLIC_TARGET_IP)
+
+    nest_proxy = NestProxy()
+    app = create_application(lambda mac_addr: nest_proxy.get_device_info(mac_addr))
     server = hass.loop.create_task(web._run_app(app, host=local_ip, port=local_port, access_log=access_log))
     LOGGER.info('Wibeee Nest proxy listening on http://%s:%d', local_ip, local_port)
 
@@ -126,13 +124,13 @@ async def get_nest_proxy(
     return nest_proxy
 
 
-async def extract_query_params(req: web.Request) -> Tuple[str, Dict, Optional[str]]:
+async def extract_query_params(req: web.Request) -> Tuple[Optional[str], Dict, Optional[str]]:
     """Extracts Wibeee data from query params."""
     query = {k: v for k, v in parse_qsl(req.query_string)}
     return query['mac'], query, await req.text() if req.can_read_body else None
 
 
-async def extract_json_body(req: web.Request) -> Tuple[Optional[str], Dict, str]:
+async def extract_json_body(req: web.Request) -> Tuple[Optional[str], Dict, Optional[str]]:
     """Extracts Wibeee data from JSON request body."""
     body = await req.text() if req.can_read_body else None
     LOGGER.debug("Parsing JSON in %s %s", req.method, req.path, body)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1771,6 +1771,26 @@ pluggy = ">=1.3.0,<2.0"
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-aiohttp"
+version = "1.0.5"
+description = "Pytest plugin for aiohttp support"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pytest-aiohttp-1.0.5.tar.gz", hash = "sha256:880262bc5951e934463b15e3af8bb298f11f7d4d3ebac970aab425aff10a780a"},
+    {file = "pytest_aiohttp-1.0.5-py3-none-any.whl", hash = "sha256:63a5360fd2f34dda4ab8e6baee4c5f5be4cd186a403cabd498fced82ac9c561e"},
+]
+
+[package.dependencies]
+aiohttp = ">=3.8.1"
+pytest = ">=6.1.0"
+pytest-asyncio = ">=0.17.2"
+
+[package.extras]
+testing = ["coverage (==6.2)", "mypy (==0.931)"]
+
+[[package]]
 name = "pytest-asyncio"
 version = "0.23.5"
 description = "Pytest support for asyncio"
@@ -2486,4 +2506,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "fe015f8469682253ae87178daad99246dc05eeba9be0269b5cc6f944eaf9cc65"
+content-hash = "c4c139c26dfecf2d589a2347481998e43b4c2e40f64b6a818f3f40b345b401e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ lxml = ">=4.9.1,<6"
 pytest = "^8.0.0"
 aioresponses = "^0.7.6"
 pytest-asyncio = "^0.23.5"
+pytest-aiohttp = "1.0.5"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_nest.py
+++ b/tests/test_nest.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from wibeee.const import NEST_NULL_UPSTREAM
+from wibeee.nest import create_application, DeviceConfig
+
+
+@pytest_asyncio.fixture
+async def nest_fixture(aiohttp_client):
+    handle_push_data = MagicMock()
+    device_config = DeviceConfig(handle_push_data, NEST_NULL_UPSTREAM)
+    app = create_application(lambda _: device_config)
+    client = await aiohttp_client(app)
+
+    return [handle_push_data, client]
+
+
+PUSH_DATA = {'mac': '001122334455', 'ip': '127.0.0.1', 'soft': '3.3.614', 'model': 'WBM', 'time': '1740333343', 'v1': '242.75',
+             'v2': '0.00', 'v3': '0.00', 'vt': '0.00', 'i1': '3.59', 'i2': '0.00', 'i3': '0.00', 'it': '0.00', 'p1': '871', 'p2': '0',
+             'p3': '0', 'pt': '0', 'a1': '610', 'a2': '0', 'a3': '0', 'at': '0', 'r1': '-615', 'r2': '0', 'r3': '0', 'rt': '0',
+             'q1': '49.93', 'q2': '0.00', 'q3': '0.00', 'qt': '0.00', 'f1': '0.700', 'f2': '0.000', 'f3': '0.000', 'ft': '0.000',
+             'e1': '6439820', 'e2': '0', 'e3': '0', 'et': '0', 'o1': '0', 'o2': '0', 'o3': '0', 'ot': '0'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method, path, param", [
+    ("get", "receiver", "params"),
+    ("get", "receiverAvg", "params"),
+    ("get", "receiverLeap", "params"),
+    ("post", "receiverAvgPost", "json"),
+    ("post", "receiverJSON", "json"),
+])
+async def test_null_upstream(nest_fixture, method, path, param):
+    handle_push_data, client = nest_fixture
+
+    res = await getattr(client, method)(f'/Wibeee/{path}', **({param: PUSH_DATA}))
+    assert res.status == 202
+
+    handle_push_data.assert_called_with(PUSH_DATA)


### PR DESCRIPTION
Attempt to solve #99 by updating Nest Proxy responses in Local-only to emulate the responses returned by Nest Cloud.