### PR TITLE
fix: async_migrate_entry error when setting version

### DIFF
--- a/custom_components/wibeee/__init__.py
+++ b/custom_components/wibeee/__init__.py
@@ -76,8 +76,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
         new_options = {k: v for k, v in options.items() if k != v1_conf_nest_proxy_enable} | {CONF_NEST_UPSTREAM: nest_upstream}
 
-        config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, options=new_options)
+        hass.config_entries.async_update_entry(config_entry, version=2, options=new_options)
         _LOGGER.info("Migration to version %s successful", config_entry.version)
 
     return True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -63,3 +63,15 @@ async def test_device_registry(spy_async_add_entities, mock_async_fetch_device_i
         'Wibeee 3Ph Phase Voltage L1': ('wibeee', '11:00:11:00:11:00'),
         'Wibeee 1Ph Phase Voltage L1': None,
     }
+
+
+@patch.object(WibeeeAPI, 'async_fetch_values', autospec=True)
+@patch.object(WibeeeAPI, 'async_fetch_device_info', autospec=True)
+async def test_migrate_entry(mock_async_fetch_device_info, mock_async_fetch_values, hass: HomeAssistant):
+    entry = MockConfigEntry(domain='wibeee', data={'host': '127.0.0.1'}, version=1)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    configured_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    assert configured_entry.version == 2


### PR DESCRIPTION
Fixes this error found while testing.

```
ERROR:homeassistant.config_entries:Error migrating entry Mock Title for wibeee
Traceback (most recent call last):
  File "/Users/luis/Workspace/hass_wibeee/.venv/lib/python3.12/site-packages/homeassistant/config_entries.py", line 978, in async_migrate
    result = await component.async_migrate_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/luis/Workspace/hass_wibeee/custom_components/wibeee/__init__.py", line 79, in async_migrate_entry
    config_entry.version = 2
    ^^^^^^^^^^^^^^^^^^^^
  File "/Users/luis/Workspace/hass_wibeee/.venv/lib/python3.12/site-packages/homeassistant/config_entries.py", line 463, in __setattr__
    raise AttributeError(
AttributeError: version cannot be changed directly, use async_update_entry instead
```