### PR TITLE
fix: don't use device_class=energy for sensors using varh as the unit

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           target-branch: ${{ github.ref_name }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
       - name: Create Release ZIP

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -105,8 +105,8 @@ KNOWN_SENSORS = [
     SensorType('eac', 'e', 'Active_Energy', 'Active Energy', UnitOfEnergy.WATT_HOUR, SensorDeviceClass.ENERGY),
     SensorType('eaccons', None, 'Active_Energy_Consumed', 'Active Energy Consumed', UnitOfEnergy.WATT_HOUR, SensorDeviceClass.ENERGY),
     SensorType('eacprod', None, 'Active_Energy_Produced', 'Active Energy Produced', UnitOfEnergy.WATT_HOUR, SensorDeviceClass.ENERGY),
-    SensorType('ereact', 'o', 'Inductive_Reactive_Energy', 'Inductive Reactive Energy', ENERGY_VOLT_AMPERE_REACTIVE_HOUR, SensorDeviceClass.ENERGY),
-    SensorType('ereactc', None, 'Capacitive_Reactive_Energy', 'Capacitive Reactive Energy', ENERGY_VOLT_AMPERE_REACTIVE_HOUR, SensorDeviceClass.ENERGY),
+    SensorType('ereact', 'o', 'Inductive_Reactive_Energy', 'Inductive Reactive Energy', ENERGY_VOLT_AMPERE_REACTIVE_HOUR, ENERGY_VOLT_AMPERE_REACTIVE_HOUR),
+    SensorType('ereactc', None, 'Capacitive_Reactive_Energy', 'Capacitive Reactive Energy', ENERGY_VOLT_AMPERE_REACTIVE_HOUR, ENERGY_VOLT_AMPERE_REACTIVE_HOUR),
 ]
 
 KNOWN_MODELS = {


### PR DESCRIPTION
Clears the following warning from logs.

```
WARNING  homeassistant.components.sensor:__init__.py:709 Entity sensor.wibeee_00_11_00_11_00_11_capacitive_reactive_energy_l1 (<class 'custom_components.wibeee.sensor.WibeeeSensor'>) is using native unit of measurement 'varh' which is not a valid unit for the device class ('energy') it is using; expected one of ['TWh', 'GJ', 'GWh', 'kcal', 'MWh', 'kJ', 'MJ', 'mWh', 'Mcal', 'Wh', 'kWh', 'Gcal', 'J', 'cal']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/luuuis/hass_wibeee/issues
WARNING  homeassistant.components.sensor:__init__.py:709 Entity sensor.wibeee_00_11_00_11_00_11_inductive_reactive_energy_l1 (<class 'custom_components.wibeee.sensor.WibeeeSensor'>) is using native unit of measurement 'varh' which is not a valid unit for the device class ('energy') it is using; expected one of ['TWh', 'GJ', 'GWh', 'kcal', 'MWh', 'kJ', 'MJ', 'mWh', 'Mcal', 'Wh', 'kWh', 'Gcal', 'J', 'cal']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/luuuis/hass_wibeee/issues
```