### PR TITLE
feat: use Local-only mode by default (no polling)

### DIFF
--- a/custom_components/wibeee/config_flow.py
+++ b/custom_components/wibeee/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.selector import SelectSelectorConfig, SelectSelectorMode, SelectSelector
 
 from .api import WibeeeAPI
-from .const import DOMAIN, DEFAULT_SCAN_INTERVAL, CONF_NEST_UPSTREAM, NEST_ALL_UPSTREAMS, NEST_PROXY_DISABLED
+from .const import DOMAIN, DEFAULT_SCAN_INTERVAL, CONF_NEST_UPSTREAM, NEST_ALL_UPSTREAMS, NEST_NULL_UPSTREAM
 from .util import short_mac
 
 _LOGGER = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ class WibeeeOptionsFlowHandler(config_entries.OptionsFlow):
             ): int,
             vol.Required(
                 CONF_NEST_UPSTREAM,
-                default=self.config_entry.options.get(CONF_NEST_UPSTREAM, NEST_PROXY_DISABLED)
+                default=self.config_entry.options.get(CONF_NEST_UPSTREAM, NEST_NULL_UPSTREAM)
             ): SelectSelector(SelectSelectorConfig(options=NEST_ALL_UPSTREAMS, mode=SelectSelectorMode.DROPDOWN))
         })
 

--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.selector import SelectOptionDict
 DOMAIN = 'wibeee'
 NEST_DEFAULT_UPSTREAM = 'http://nest-ingest.wibeee.com'
 
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=0)
 DEFAULT_TIMEOUT = timedelta(seconds=10)
 
 CONF_NEST_UPSTREAM = 'nest_upstream'


### PR DESCRIPTION
Disable polling by default. Move towards Local Push-only, which is how Wibeee Nest works. This should help greatly with device stability.