### PR TITLE
feat: update device and sensor names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 venv/
 dist/
+config/

--- a/README.md
+++ b/README.md
@@ -13,21 +13,22 @@ versions.
 
 Provides the following sensors, one for each clamp using `_L1`/`_L2`/`_L3` suffixes.
 
-| Sensor                                         | Unit  | Description       |
-| -----------------------------------------------|:------:|------------------|
-| `wibeee_<mac_addr>_active_energy`              | Wh    | Active Energy |
-| `wibeee_<mac_addr>_active_energy_produced`     | Wh    | Active Energy Produced |
-| `wibeee_<mac_addr>_active_energy_consumed`     | Wh    | Active Energy Consumed |
-| `wibeee_<mac_addr>_active_power`               | W     | Active Power |
-| `wibeee_<mac_addr>_apparent_power`             | VA    | Apparent Power |
-| `wibeee_<mac_addr>_capacitive_reactive_energy` | VArCh | Capacitive Reactive Energy |
-| `wibeee_<mac_addr>_capacitive_reactive_power`  | VArC  | Capacitive Reactive Power |
-| `wibeee_<mac_addr>_frequency`                  | Hz    | Frequency |
-| `wibeee_<mac_addr>_inductive_reactive_energy`  | VArLh | Inductive Reactive Energy |
-| `wibeee_<mac_addr>_inductive_reactive_power`   | VArL  | Inductive Reactive Power |
-| `wibeee_<mac_addr>_current`                    | A     | Current |
-| `wibeee_<mac_addr>_power_factor`               | PF    | Power Factor |
-| `wibeee_<mac_addr>_phase_voltage`              | V     | Phase Voltage |
+| Sensor                                            | Unit | Description                |
+|---------------------------------------------------|:----:|----------------------------|
+| `wibeee_<mac_addr>_l1_active_energy`              |  Wh  | Active Energy              |
+| `wibeee_<mac_addr>_l1_active_energy_produced`     |  Wh  | Active Energy Produced     |
+| `wibeee_<mac_addr>_l1_active_energy_consumed`     |  Wh  | Active Energy Consumed     |
+| `wibeee_<mac_addr>_l1_active_power`               |  W   | Active Power               |
+| `wibeee_<mac_addr>_l1_apparent_power`             |  VA  | Apparent Power             |
+| `wibeee_<mac_addr>_l1_capacitive_reactive_energy` | varh | Capacitive Reactive Energy |
+| `wibeee_<mac_addr>_l1_capacitive_reactive_power`  | var  | Capacitive Reactive Power  |
+| `wibeee_<mac_addr>_l1_frequency`                  |  Hz  | Frequency                  |
+| `wibeee_<mac_addr>_l1_inductive_reactive_energy`  | varh | Inductive Reactive Energy  |
+| `wibeee_<mac_addr>_l1_inductive_reactive_power`   | var  | Inductive Reactive Power   |
+| `wibeee_<mac_addr>_l1_reactive_power`             | var  | Reactive Power             |
+| `wibeee_<mac_addr>_l1_current`                    |  A   | Current                    |
+| `wibeee_<mac_addr>_l1_power_factor`               |  PF  | Power Factor               |
+| `wibeee_<mac_addr>_l1_phase_voltage`              |  V   | Phase Voltage              |
 
 In three-phase devices the `_L4` sensors contain the total readings across all phases.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ versions.
 
 ### Sensors
 
-Provides the following sensors, one for each clamp using `_L1`/`_L2`/`_L3` suffixes.
+Provides the following sensors, one for each circuit using `l1`/`l2`/`l3` in the name and entity id. For three-phase
+devices there is an additional device and set of sensors containing the total readings across all phases.
 
 | Sensor                                            | Unit | Description                |
 |---------------------------------------------------|:----:|----------------------------|
@@ -30,7 +31,6 @@ Provides the following sensors, one for each clamp using `_L1`/`_L2`/`_L3` suffi
 | `wibeee_<mac_addr>_l1_power_factor`               |  PF  | Power Factor               |
 | `wibeee_<mac_addr>_l1_phase_voltage`              |  V   | Phase Voltage              |
 
-In three-phase devices the `_L4` sensors contain the total readings across all phases.
 
 ## Installation
 

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,0 +1,4 @@
+logger:
+  default: info
+  logs:
+    custom_components.wibeee: debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: 'latest'
+
+services:
+  home-assistant:
+    container_name: homeassistant_wibeee
+    image: ghcr.io/home-assistant/home-assistant:2025.1.1
+    environment:
+      - TZ=UTC
+    ports:
+      - "9123:8123"
+    volumes:
+      - ./config:/config
+      - ./custom_components:/config/custom_components
+    command: >
+      python -m homeassistant --config /config


### PR DESCRIPTION
Catching up to [July 10, 2022: Adopting a new way to name entities](https://developers.home-assistant.io/blog/2022/07/10/entity_naming/). Makes it easier to have entity ids and friendly names updated accordingly if the parent device is renamed.

<img width="676" alt="image" src="https://github.com/user-attachments/assets/c0ec9c46-b21a-4de1-8389-586da403ca98" />

⚠️ Entity ids are changed.