### PR TITLE
chore: include MAC address and Wibeee ID in ConfigEntry

### DIFF
--- a/custom_components/wibeee/config_flow.py
+++ b/custom_components/wibeee/config_flow.py
@@ -14,7 +14,15 @@ from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.selector import SelectSelectorConfig, SelectSelectorMode, SelectSelector
 
 from .api import WibeeeAPI
-from .const import DOMAIN, DEFAULT_SCAN_INTERVAL, CONF_NEST_UPSTREAM, NEST_ALL_UPSTREAMS, NEST_NULL_UPSTREAM
+from .const import (
+    DOMAIN,
+    DEFAULT_SCAN_INTERVAL,
+    CONF_MAC_ADDRESS,
+    CONF_NEST_UPSTREAM,
+    CONF_WIBEEE_ID,
+    NEST_ALL_UPSTREAMS,
+    NEST_NULL_UPSTREAM,
+)
 from .util import short_mac
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,12 +41,16 @@ async def validate_input(hass: HomeAssistant, user_input: dict) -> [str, str, di
     unique_id = mac_addr
     name = f"Wibeee {short_mac(mac_addr)}"
 
-    return name, unique_id, {CONF_HOST: user_input[CONF_HOST], }
+    return name, unique_id, {
+        CONF_HOST: user_input[CONF_HOST],
+        CONF_MAC_ADDRESS: device.macAddr,
+        CONF_WIBEEE_ID: device.id,
+    }
 
 
 class WibeeeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Wibeee config flow."""
-    VERSION = 2
+    VERSION = 3
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""

--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -10,6 +10,12 @@ DEFAULT_TIMEOUT = timedelta(seconds=10)
 
 CONF_NEST_UPSTREAM = 'nest_upstream'
 
+CONF_MAC_ADDRESS = 'mac_address'
+"""Device's MAC address."""
+
+CONF_WIBEEE_ID = 'wibeee_id'
+"""Device's Wibeee ID, used for polling values.xml API."""
+
 
 def _format_options(upstreams: dict[str, str]) -> list[SelectOptionDict]:
     return [SelectOptionDict(label=f'{cloud} ({url})', value=url) for cloud, url in upstreams.items()]

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -5,7 +5,6 @@ Vendor docs: https://support.wibeee.com/space/CH/184025089/XML
 Documentation: https://github.com/luuuis/hass_wibeee/
 
 """
-from . import CONF_MAC_ADDRESS
 
 REQUIREMENTS = ["xmltodict"]
 

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -5,6 +5,7 @@ Vendor docs: https://support.wibeee.com/space/CH/184025089/XML
 Documentation: https://github.com/luuuis/hass_wibeee/
 
 """
+from . import CONF_MAC_ADDRESS
 
 REQUIREMENTS = ["xmltodict"]
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -85,10 +85,10 @@ async def test_sensor_ids_and_names(spy_async_add_entities, mock_async_fetch_dev
 @patch.object(WibeeeAPI, 'async_fetch_values', autospec=True)
 @patch.object(WibeeeAPI, 'async_fetch_device_info', autospec=True)
 async def test_migrate_entry(mock_async_fetch_device_info, mock_async_fetch_values, hass: HomeAssistant):
+    entry = MockConfigEntry(domain='wibeee', data={'host': '127.0.0.2'}, version=1)
     info = DeviceInfo('ozymandias', 'abcdabcdabcd', '4.5.6', 'WBB', '127.0.0.2')
     mock_async_fetch_device_info.return_value = info
 
-    entry = MockConfigEntry(domain='wibeee', data={'host': '127.0.0.2'}, version=1)
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
Including these two pieces of information in the `ConfigEntry` allows us to create all sensors without having to use the device API, which is notoriously unstable.

Introduces an extra API call that is made when the `ConfigEntry` is upgraded in order to initially populate the data.

Added Docker files for local end-to-end testing.