### PR TITLE
chore: disable polling on device when upgrading to v4.x

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -109,7 +109,7 @@ async def test_sensor_ids_and_names(spy_async_add_entities, mock_async_fetch_dev
 
 
 @patch.object(WibeeeAPI, 'async_fetch_device_info', autospec=True)
-async def test_migrate_entry(mock_async_fetch_device_info, hass: HomeAssistant):
+async def test_migrate_entry_1_to_3(mock_async_fetch_device_info, hass: HomeAssistant):
     entry = MockConfigEntry(domain='wibeee', data={'host': '127.0.0.2'}, version=1)
     info = DeviceInfo('ozymandias', 'abcdabcdabcd', '4.5.6', 'WBB', '127.0.0.2')
 
@@ -124,12 +124,13 @@ async def test_migrate_entry(mock_async_fetch_device_info, hass: HomeAssistant):
         'mac_address': 'abcdabcdabcd',  # to set up local push
         'wibeee_id': 'ozymandias',  # Wibeee id, needed for values.xml API
     }
+    assert configured_entry.options == {'scan_interval': 0.0, 'nest_upstream': 'proxy_null'}
     assert configured_entry.version == 3
 
 
 @patch.object(er, 'async_entries_for_config_entry', autospec=True)
-async def test_migrate_entry_offline(mock_async_entries_for_config_entry, hass: HomeAssistant):
-    entry = MockConfigEntry(domain='wibeee', data={'host': '127.0.0.2'}, version=1)
+async def test_migrate_entry_2_to_3_offline(mock_async_entries_for_config_entry, hass: HomeAssistant):
+    entry = MockConfigEntry(domain='wibeee', data={'host': '127.0.0.2'}, options={'scan_interval': 30, 'nest_upstream': 'proxy_disabled'}, version=2)
     mock_async_entries_for_config_entry.side_effect = lambda _, entry_id: [] if entry_id != entry.entry_id else [
         # self._attr_unique_id = f"_{mac_addr}_{sensor_type.unique_name.lower()}_{sensor_phase}"
         # self._attr_name = f"{device_name} {sensor_type.friendly_name} L{sensor_phase}"
@@ -148,6 +149,7 @@ async def test_migrate_entry_offline(mock_async_entries_for_config_entry, hass: 
         'mac_address': 'abcdabcdabcd',  # to set up local push
         'wibeee_id': 'Downstairs',  # Wibeee id, needed for values.xml API
     }
+    assert configured_entry.options == {'scan_interval': 0.0, 'nest_upstream': 'proxy_null'}
     assert configured_entry.version == 3
 
 


### PR DESCRIPTION
Disable polling on each upgraded ConfigEntry. Local Push will be the only option in v4.x but for now polling can still be re-enabled manually by users after the upgrade.

In the same vein, when upgrading a `ConfigEntry` we now try to do so without calling out to the device. If that fails then we resort to a `/services/user/devices.xml` call.