### PR TITLE
fix: missing state_class on _power_factor sensors

### DIFF
--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -130,7 +130,7 @@ class SensorType(NamedTuple):
         if self.device_class in ENERGY_CLASSES:
             return SensorStateClass.TOTAL_INCREASING
 
-        if self.unit:
+        if self.unit or self.device_class:
             return SensorStateClass.MEASUREMENT
 
         return None


### PR DESCRIPTION
Introduced in #137 .

<img width="586" alt="image" src="https://github.com/user-attachments/assets/18aca606-76a4-468b-a230-42604b71ba9d" />
