### PR TITLE
feat: several improvements around the "WIBEEE is not receiving updates" repair

### DIFF
--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -152,7 +152,7 @@ async def extract_query_params(req: web.Request) -> DecodedRequest:
 async def extract_json_body(req: web.Request) -> DecodedRequest:
     """Extracts Wibeee data from JSON request body."""
     body = await req.text() if req.can_read_body else None
-    LOGGER.debug("Parsing JSON in %s %s", req.method, req.path, body)
+    LOGGER.debug("Parsing JSON in %s %s", req.method, req.path)
     parsed_body = None
     parse_error = None
     try:

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -324,9 +324,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
 def setup_issue_maintainer(hass: HomeAssistant, entry: ConfigEntry, sensors: list['WibeeeSensor']) -> CALLBACK_TYPE:
     issue_id = f'{entry.entry_id}_local_push'
+    stale_threshold = timedelta(minutes=1)
 
     async def check_for_stale_states(now: datetime):
-        stale_cutoff_time = now - timedelta(minutes=2)
+        stale_cutoff_time = now - (stale_threshold * 1.5)
         stale_states = {sensor: state for sensor in sensors
                         if (state := hass.states.get(sensor.entity_id))
                         if state and state.last_reported < stale_cutoff_time}
@@ -353,7 +354,7 @@ def setup_issue_maintainer(hass: HomeAssistant, entry: ConfigEntry, sensors: lis
         else:
             async_delete_issue(hass, DOMAIN, issue_id)
 
-    return async_track_time_interval(hass, check_for_stale_states, timedelta(seconds=10), name=f'Wibeee {issue_id} issue_maintainer')
+    return async_track_time_interval(hass, check_for_stale_states, stale_threshold * 2, name=f'Wibeee {issue_id} issue_maintainer')
 
 
 class WibeeeSensor(SensorEntity):

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -105,7 +105,7 @@ class SensorType(NamedTuple):
     """
     poll_var_prefix: str
     "prefix used for elements in `values.xml` output (e.g.: 'vrms')"
-    push_var_prefix: Optional[str]
+    push_var_prefix: str
     "prefix used in Wibeee Nest push requests such as receiverLeap (e.g.: 'v')"
     friendly_name: str
     "used to build the sensor name and entity id (e.g.: 'Phase Voltage')"
@@ -145,10 +145,7 @@ KNOWN_SENSORS = (
     SensorType('pap', 'p', 'Apparent Power', UnitOfApparentPower.VOLT_AMPERE, SensorDeviceClass.APPARENT_POWER),
     SensorType('fpot', 'f', 'Power Factor', None, SensorDeviceClass.POWER_FACTOR),
     SensorType('eac', 'e', 'Active Energy', UnitOfEnergy.WATT_HOUR, SensorDeviceClass.ENERGY),
-    SensorType('eaccons', None, 'Active Energy Consumed', UnitOfEnergy.WATT_HOUR, SensorDeviceClass.ENERGY),
-    SensorType('eacprod', None, 'Active Energy Produced', UnitOfEnergy.WATT_HOUR, SensorDeviceClass.ENERGY),
     SensorType('ereactl', 'o', 'Inductive Reactive Energy', ENERGY_VOLT_AMPERE_REACTIVE_HOUR, ENERGY_VOLT_AMPERE_REACTIVE_HOUR),
-    SensorType('ereactc', None, 'Capacitive Reactive Energy', ENERGY_VOLT_AMPERE_REACTIVE_HOUR, ENERGY_VOLT_AMPERE_REACTIVE_HOUR),
     # Diagnostic sensors:
     SensorType('macAddr', 'mac', 'MAC Address', entity_category=EntityCategory.DIAGNOSTIC, slots=(Slot.Device,)),
     SensorType('ipAddr', 'ip', 'IP Address', entity_category=EntityCategory.DIAGNOSTIC, slots=(Slot.Device,)),

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -342,11 +342,14 @@ def setup_issue_maintainer(hass: HomeAssistant, entry: ConfigEntry, sensors: lis
 
             last_updated = max([state.last_updated for state in stale_states.values()])
             async_create_issue(hass, DOMAIN, issue_id,
-                         is_fixable=False,
-                         severity=ir.IssueSeverity.WARNING,
-                         translation_key="wibeee_local_push_not_received",
-                         translation_placeholders={"device_name": device_name, "last_updated": last_updated.ctime()},
-                         learn_more_url='https://github.com/luuuis/hass_wibeee/tree/main?tab=readme-ov-file#-configuring-local-push')
+                               is_fixable=False,
+                               severity=ir.IssueSeverity.WARNING,
+                               translation_key=f'local_push_not_received_all' if len(stale_states) == len(sensors)
+                                               else 'local_push_not_received_partial',
+                               translation_placeholders=dict(sensor_count=len(stale_states),
+                                                             device_name=device_name,
+                                                             last_updated=last_updated.ctime()),
+                               learn_more_url='https://github.com/luuuis/hass_wibeee/tree/main?tab=readme-ov-file#-configuring-local-push')
         else:
             async_delete_issue(hass, DOMAIN, issue_id)
 

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -324,7 +324,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
 
 def setup_repairs(hass: HomeAssistant, entry: ConfigEntry, sensors: list['WibeeeSensor']) -> CALLBACK_TYPE:
-    issue_id = f'{entry.entry_id}_local_push'
+    issue_id = f'wibeee_stale_states_checker_{entry.entry_id}'
     stale_threshold = timedelta(minutes=1)
 
     async def check_for_stale_states(now: datetime):
@@ -355,7 +355,7 @@ def setup_repairs(hass: HomeAssistant, entry: ConfigEntry, sensors: list['Wibeee
         else:
             async_delete_issue(hass, DOMAIN, issue_id)
 
-    return async_track_time_interval(hass, check_for_stale_states, stale_threshold * 2, name=f'Wibeee {entry.unique_id} setup_repairs')
+    return async_track_time_interval(hass, check_for_stale_states, stale_threshold * 2, name=issue_id)
 
 
 class WibeeeSensor(SensorEntity):

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -329,7 +329,7 @@ def setup_issue_maintainer(hass: HomeAssistant, entry: ConfigEntry, sensors: lis
         stale_cutoff_time = now - timedelta(minutes=2)
         stale_states = {sensor: state for sensor in sensors
                         if (state := hass.states.get(sensor.entity_id))
-                        if state and state.last_updated < stale_cutoff_time}
+                        if state and state.last_reported < stale_cutoff_time}
 
         if stale_states:
             _LOGGER.debug("issue_maintainer found %d stale states", len(stale_states))
@@ -340,7 +340,7 @@ def setup_issue_maintainer(hass: HomeAssistant, entry: ConfigEntry, sensors: lis
             if sensors_to_make_unavailable:
                 update_sensors(sensors_to_make_unavailable, 'issue_maintainer', lambda k: k, {})
 
-            last_updated = max([state.last_updated for state in stale_states.values()])
+            last_reported = max([state.last_reported for state in stale_states.values()])
             async_create_issue(hass, DOMAIN, issue_id,
                                is_fixable=False,
                                severity=ir.IssueSeverity.WARNING,
@@ -348,7 +348,7 @@ def setup_issue_maintainer(hass: HomeAssistant, entry: ConfigEntry, sensors: lis
                                                else 'local_push_not_received_partial',
                                translation_placeholders=dict(sensor_count=len(stale_states),
                                                              device_name=device_name,
-                                                             last_updated=last_updated.ctime()),
+                                                             last_reported=last_reported.ctime()),
                                learn_more_url='https://github.com/luuuis/hass_wibeee/tree/main?tab=readme-ov-file#-configuring-local-push')
         else:
             async_delete_issue(hass, DOMAIN, issue_id)

--- a/custom_components/wibeee/sensor.py
+++ b/custom_components/wibeee/sensor.py
@@ -48,6 +48,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.issue_registry import async_create_issue, async_delete_issue
 from homeassistant.helpers.typing import StateType
+from homeassistant.util.dt import as_local
 
 from .api import WibeeeAPI, DeviceInfo, WibeeeID
 from .const import (
@@ -349,7 +350,7 @@ def setup_issue_maintainer(hass: HomeAssistant, entry: ConfigEntry, sensors: lis
                                                else 'local_push_not_received_partial',
                                translation_placeholders=dict(sensor_count=len(stale_states),
                                                              device_name=device_name,
-                                                             last_reported=last_reported.ctime()),
+                                                             last_reported=as_local(last_reported).ctime()),
                                learn_more_url='https://github.com/luuuis/hass_wibeee/tree/main?tab=readme-ov-file#-configuring-local-push')
         else:
             async_delete_issue(hass, DOMAIN, issue_id)

--- a/custom_components/wibeee/translations/en.json
+++ b/custom_components/wibeee/translations/en.json
@@ -32,11 +32,11 @@
   "issues": {
     "local_push_not_received_all": {
       "title": "{device_name} is not receiving updates",
-      "description": "{device_name} has not received an update since {last_updated}.\n\nConfigure Local Push to get updates when sensor values change."
+      "description": "{device_name} has not received an update since {last_reported}.\n\nConfigure Local Push to get updates when sensor values change."
     },
     "local_push_not_received_partial": {
       "title": "{device_name} is not receiving updates for all sensors",
-      "description": "{device_name} has not received an update on {sensor_count} of its sensors since {last_updated}.\n\nConfigure Local Push to get updates when sensor values change."
+      "description": "{device_name} has not received an update on {sensor_count} of its sensors since {last_reported}.\n\nConfigure Local Push to get updates when sensor values change."
     }
   }
 }

--- a/custom_components/wibeee/translations/en.json
+++ b/custom_components/wibeee/translations/en.json
@@ -30,9 +30,13 @@
     }
   },
   "issues": {
-    "wibeee_local_push_not_received": {
+    "local_push_not_received_all": {
       "title": "{device_name} is not receiving updates",
-      "description": "{device_name} has not received an update since {last_updated}. Configure Local Push to get updates when sensor values change."
+      "description": "{device_name} has not received an update since {last_updated}.\n\nConfigure Local Push to get updates when sensor values change."
+    },
+    "local_push_not_received_partial": {
+      "title": "{device_name} is not receiving updates for all sensors",
+      "description": "{device_name} has not received an update on {sensor_count} of its sensors since {last_updated}.\n\nConfigure Local Push to get updates when sensor values change."
     }
   }
 }


### PR DESCRIPTION
Changes:
1. Show different "Repair" text depending on whether all or only some sensors are not updated 
2. Removed sensors that don't receive push updates.
3. Use `last_reported` instead of `last_updated`. The former is set even when the sensor values/attributes remain unchanged.
4. Set state threshold to 90s, re-check every 120s.

<img width="350" alt="Screenshot 2025-04-02 at 16 30 25" src="https://github.com/user-attachments/assets/ec29e288-0dcb-4366-aa65-d7ced76c4cf4" />
<img width="350" alt="Screenshot 2025-04-02 at 16 31 04" src="https://github.com/user-attachments/assets/3abcd49f-0ce7-4a3e-a673-6addffbacefa" />
