### PR TITLE
fix: logging error at DEBUG level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 venv/
 dist/
+config/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 python 3.13.2
+poetry 2.1.3

--- a/custom_components/wibeee/nest.py
+++ b/custom_components/wibeee/nest.py
@@ -10,6 +10,7 @@ from homeassistant.components.network import async_get_source_ip
 from homeassistant.components.network.const import PUBLIC_TARGET_IP
 from homeassistant.core import callback, Event
 from homeassistant.helpers import singleton
+
 from .const import NEST_NULL_UPSTREAM
 
 LOGGER = logging.getLogger(__name__)
@@ -149,7 +150,7 @@ async def extract_query_params(req: web.Request) -> DecodedRequest:
 async def extract_json_body(req: web.Request) -> DecodedRequest:
     """Extracts Wibeee data from JSON request body."""
     body = await req.text() if req.can_read_body else None
-    LOGGER.debug("Parsing JSON in %s %s", req.method, req.path, body)
+    LOGGER.debug("Parsing JSON in %s %s", req.method, req.path)
     parsed_body = None
     parse_error = None
     try:


### PR DESCRIPTION
Fixes this in v3.x, which happens only when DEBUG logging enabled.

```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/logging/handlers.py", line 1509, in emit
    self.enqueue(self.prepare(record))
                 ~~~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.13/logging/handlers.py", line 1491, in prepare
    msg = self.format(record)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.13/logging/__init__.py", line 712, in format
    record.message = record.getMessage()
                     ~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/logging/__init__.py", line 400, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "<frozen runpy>", line 198, in _run_module_as_main
  ...
Message: 'Parsing JSON in %s %s'
Arguments: ('POST', '/Wibeee/receiverAvgPost', ...)
```