### PR TITLE
feat: add Iberdrola (wibeee.com) Nest upstream option

### DIFF
--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -22,15 +22,15 @@ DEFAULT_THROTTLE = timedelta(seconds=5)
 """Default minimum interval between sensor updates."""
 
 
-def _format_options(upstreams: dict[str, str]) -> list[SelectOptionDict]:
-    return [SelectOptionDict(label=f'{cloud} ({url})', value=url) for cloud, url in upstreams.items()]
+def _format_options(upstreams: list[tuple[str, str]]) -> list[SelectOptionDict]:
+    return [SelectOptionDict(label=f'{cloud} ({url})', value=url) for cloud, url in upstreams]
 
 
 NEST_NULL_UPSTREAM: str = 'proxy_null'
 NEST_ALL_UPSTREAMS: list[SelectOptionDict] = [SelectOptionDict(label='Local only (no Cloud)', value=NEST_NULL_UPSTREAM)] + \
-                                             _format_options({
-                                                 'Wibeee Nest': NEST_DEFAULT_UPSTREAM,
-                                                 'Iberdrola': 'http://datosmonitorconsumo.iberdrola.es:8080',
-                                                 'Iberdrola (wibeee.com)': 'http://ingest-prod-iberdrola.wibeee.com:80',
-                                                 'SolarProfit': 'http://wdata.solarprofit.es:8080',
-                                             })
+                                             _format_options([
+                                                 ('Wibeee Nest', NEST_DEFAULT_UPSTREAM),
+                                                 ('Iberdrola', 'http://datosmonitorconsumo.iberdrola.es:8080'),
+                                                 ('Iberdrola', 'http://ingest-prod-iberdrola.wibeee.com:80'),
+                                                 ('SolarProfit', 'http://wdata.solarprofit.es:8080'),
+                                             ])

--- a/custom_components/wibeee/const.py
+++ b/custom_components/wibeee/const.py
@@ -31,5 +31,6 @@ NEST_ALL_UPSTREAMS: list[SelectOptionDict] = [SelectOptionDict(label='Local only
                                              _format_options({
                                                  'Wibeee Nest': NEST_DEFAULT_UPSTREAM,
                                                  'Iberdrola': 'http://datosmonitorconsumo.iberdrola.es:8080',
+                                                 'Iberdrola (wibeee.com)': 'http://ingest-prod-iberdrola.wibeee.com:80',
                                                  'SolarProfit': 'http://wdata.solarprofit.es:8080',
                                              })


### PR DESCRIPTION
## Summary

- Add a new Nest upstream option pointing to `http://ingest-prod-iberdrola.wibeee.com:80`, the endpoint where Iberdrola-branded Wibeee units now report by default.
- The existing "Iberdrola" option (pointing to `datosmonitorconsumo.iberdrola.es:8080`) is kept unchanged so existing configurations keep working.

## Why

Iberdrola Smart Solar installations come with a Wibeee whose firmware (4.4.171 in my unit, possibly earlier) is configured out of the box to upload to:

```
http://ingest-prod-iberdrola.wibeee.com:80
```

This is a different host than the one this integration ships as the "Iberdrola" preset (`datosmonitorconsumo.iberdrola.es:8080`). Without a matching option in the dropdown, users with newer firmware who want to keep Nest forwarding active end up having to hand-edit `.storage/core.config_entries`, which is brittle and gets lost if the integration is re-added.

The new endpoint has been verified locally:

- The Wibeee, when its `Server` setting is restored to factory defaults, sends to `ingest-prod-iberdrola.wibeee.com:80`.
- The Nest proxy in this integration forwards there without modification and Iberdrola's backend replies `200 OK` with the expected `<<<WGRADIENT=007 ` payload, identical to what the legacy host returns.
- Data continues to appear in the Iberdrola Smart Solar app after the switch.

## Test plan

- [x] Set the new option in the integration's options flow and confirm that forwarded requests are accepted by `ingest-prod-iberdrola.wibeee.com:80` (`200 OK`, valid `<<<WGRADIENT=...` payload).
- [x] Verify that the Iberdrola Smart Solar app keeps receiving data with the new upstream selected.
- [x] Verify that existing setups using the original "Iberdrola" option are unaffected (entry value unchanged, dropdown still shows the existing label).

## Notes

This is a minimal, additive change — one new line in `const.py`. The legacy "Iberdrola" entry is intentionally preserved to avoid breaking any existing installation that may still depend on it. If at some point Iberdrola fully retires the legacy host, removing it can be done in a follow-up.